### PR TITLE
Simpler

### DIFF
--- a/draft-ietf-secevent-delivery.xml
+++ b/draft-ietf-secevent-delivery.xml
@@ -130,7 +130,7 @@
               as Event Receivers. An Event Transmitter
               is responsible for offering a service that allows the Event
               Receiver to check the Event Stream configuration and status
-              known as the "Management API". 
+              known as the "Control Plane". 
             </t>
             
             <t hangText="Event Receiver"><vspace/>
@@ -139,7 +139,7 @@
               SETs via HTTP POST. 
               Event Receivers
               can check current Event Stream configuration and status by
-              accessing the Event Transmitters "Management API".
+              accessing the Event Transmitters "Control Plane".
             </t>
   
             <t hangText="Event Stream"><vspace/>

--- a/draft-ietf-secevent-delivery.xml
+++ b/draft-ietf-secevent-delivery.xml
@@ -220,10 +220,8 @@
         header of <spanx style="verb">application/secevent+jwt</spanx> 
         as defined in Section 2.2 and 6.2 of 
         <xref target="I-D.ietf-secevent-token"/>. Upon receipt, the 
-        Event Receiver acknowledges receipt with an HTTP response which 
-        is a JSON document with a <spanx style="verb">Content-Type</spanx> header of 
-        <spanx style="verb">application/json</spanx> (see Section 11 of
-        <xref target="RFC7159"/>) as described below in <xref target="httpPost"/>.</t>
+        Event Receiver acknowledges receipt with a response with HTTP 
+        Status 202, as described below in <xref target="httpPost"/>.</t>
         
         <t hangText="POLLING">Where 
         multiple SETs are delivered in a JSON document <xref target="RFC7159"/>

--- a/draft-ietf-secevent-delivery.xml
+++ b/draft-ietf-secevent-delivery.xml
@@ -125,55 +125,21 @@
 					The following definitions are defined for Security Event distribution:
 					<list style="hanging">
           
-            <t hangText="Identity Provider"><vspace/>
-              An Identity Provider is a service provider that issues authentication
-              assertions that may be used by Relying Party service providers
-              to establish login sessions with users. Examples of Identity 
-              Providers are defined in: OpenID Connect 
-              <xref target="openid-connect-core"/> and SAML2 
-              <xref target="saml-core-2.0"/>. For the purpose of this 
-              specification an Identity Provider also includes any provider
-              of services where the compromise of an account may open up 
-              relying parties to attack. For example for the purposes of
-              security events, an email service provider could be 
-              considered an "implicit" Identity Provider.
-            </t>
-              
-            <t hangText="Relying Party"><vspace/>
-              Relying Parties come in multiple forms generally classified 
-              as "Explicit" or "Implicit". An Explicit Relying Party is a 
-              service provider that accepts a standard security 
-              assertion (e.g. a JWT access tokens <xref target="RFC7519"/>)
-              from an Identity Provider to establish a session or 
-              authorization. An Implicit Relying Party (implicit) uses 
-              a personal identifier such as an email address or telephone 
-              number from another provider to establish a Subject's 
-              identity. Examples of Explicit Relying Parties are defined 
-              in: OpenID Connect <xref target="openid-connect-core"/> and 
-              SAML2 <xref target="saml-core-2.0"/>. Implicit relying 
-              parties are verified by a common channel associated with 
-              the identifier. For example, an email or a text message is
-              sent with a unique link to establish ownership of the
-              identifier by the Subject.
-            </t>          
-            
             <t hangText="Event Transmitter"><vspace/>
               A service provider that delivers SETs to other providers known
-              as Event Receivers. Some examples of Event Transmitters are 
-              Identity Providers and Relying Parties. An Event Transmitter
+              as Event Receivers. An Event Transmitter
               is responsible for offering a service that allows the Event
               Receiver to check the Event Stream configuration and status
-              known as the "Control Plane". 
+              known as the "Management API". 
             </t>
             
             <t hangText="Event Receiver"><vspace/>
               A service provider that registers to receive SETs from 
               an Event Transmitter and provides an endpoint to receive
               SETs via HTTP POST. 
-              Some examples of Event Receivers are 
-              Identity Providers and Relying Parties. Event Receivers
+              Event Receivers
               can check current Event Stream configuration and status by
-              accessing the Event Transmitters "Control Plane".
+              accessing the Event Transmitters "Management API".
             </t>
   
             <t hangText="Event Stream"><vspace/>


### PR DESCRIPTION
Two simplifying changes as mentioned in email thread:

1. In section 1.2 we could drop the definition of Identity Provider and Relying Party. I don't think these are necessary in this spec.

2. In section 2.1, the description of the PUSH delivery mode states that the response must contain "Content-Type: application/json". I think that is the case only for error responses, I think on success no Content-Type is needed at all.