### PR TITLE
Addressing comments from IETF 103

### DIFF
--- a/draft-ietf-secevent-http-push.html
+++ b/draft-ietf-secevent-http-push.html
@@ -597,13 +597,15 @@
 <a href="#rfc.section.2.1">2.1.</a> <a href="#httpPost" id="httpPost">Transmitting a SET</a>
 </h1>
 <p id="rfc.section.2.1.p.1">To transmit a SET to a SET Recipient, the SET Transmitter makes an HTTP POST request to an HTTP endpoint provided by the SET Recipient.  The <samp>Content-Type</samp> header of this request MUST be "application/secevent+jwt" as defined in Sections 2.2 and 6.2 of <a href="#RFC8417" class="xref">[RFC8417]</a>, and the <samp>Accept</samp> header MUST be "application/json".  The request body MUST consist of the SET itself, represented as a <a href="#RFC7519" class="xref">JWT</a>.  </p>
-<p id="rfc.section.2.1.p.2">The mechanisms by which the SET Transmitter determines the HTTP endpoint to use when transmitting a SET to a given SET Recipient are not defined by this specification and may be implementation-specific.  </p>
+<p id="rfc.section.2.1.p.2">The SET Transmitter MAY include in the request an <samp>Accept-Language</samp> header to indicate to the SET Recipient the preferred language(s) in which to receive error messages.  </p>
+<p id="rfc.section.2.1.p.3">The mechanisms by which the SET Transmitter determines the HTTP endpoint to use when transmitting a SET to a given SET Recipient are not defined by this specification and may be implementation-specific.  </p>
 <div id="rfc.figure.1"></div>
 <div id="postSet"></div>
 <p>The following is a non-normative example of a SET transmission request: </p>
 <pre>POST /Events  HTTP/1.1
 Host: notify.rp.example.com
 Accept: application/json
+Accept-Language: en-US, en;q=0.5
 Content-Type: application/secevent+jwt
 
 eyJhbGciOiJub25lIn0
@@ -635,20 +637,22 @@ tZSI6Impkb2UiLCJpZCI6IjQ0ZjYxNDJkZjk2YmQ2YWI2MWU3NTIxZDkiLCJuYW
 <a href="#rfc.section.2.3">2.3.</a> <a href="#failureResponse" id="failureResponse">Failure Response</a>
 </h1>
 <p id="rfc.section.2.3.p.1">In the event of a general HTTP error condition, the SET Recipient MAY respond with an appropriate HTTP Status Code as defined in Section 6 of <a href="#RFC7231" class="xref">[RFC7231]</a>.</p>
-<p id="rfc.section.2.3.p.2">When the SET Recipient detects an error parsing or validating a SET transmitted in a SET Transmission Request, the SET Recipient SHALL respond with an HTTP Response Status Code of 400 (Bad Request).  The <samp>Content-Type</samp> header of this response MUST be "application/json", and the body MUST be a <a href="#RFC7159" class="xref">JSON</a> object containing the following name/value pairs: </p>
+<p id="rfc.section.2.3.p.2">When the SET Recipient detects an error parsing or validating a SET transmitted in a SET Transmission Request, the SET Recipient SHALL respond with an HTTP Response Status Code of 400 (Bad Request).  The <samp>Content-Type</samp> header of this response MUST be "application/json", and the body MUST be a UTF-8 encoded <a href="#RFC7159" class="xref">JSON</a> object containing the following name/value pairs: </p>
 
 <dl>
 <dt>err</dt>
 <dd style="margin-left: 8">A Security Event Token Error Code (see <a href="#error_codes" class="xref">Section 2.4</a>).  </dd>
 <dt>description</dt>
-<dd style="margin-left: 8">Human-readable text that describes the error and MAY contain additional diagnostic information. The exact content of this field is implementation-specific.  </dd>
+<dd style="margin-left: 8">A UTF-8 string containing a human-readable description of the error that MAY provide additional diagnostic information. The exact content of this field is implementation-specific.  </dd>
 </dl>
 
 <p> </p>
+<p id="rfc.section.2.3.p.3">The response MUST include a <samp>Content-Language</samp> header, whose value indicates the language of the error descriptions included in the response body. If the SET Recipient can provide error descriptions in multiple languages, they SHOULD choose the language to use according to the value of the <samp>Accept-Language</samp> header sent by the SET Transmitter in the transmission request, as described in Section 5.3.5 of <a href="#RFC7231" class="xref">[RFC7231]</a>. If the SET Transmitter did not send an <samp>Accept-Language</samp> header, or if the SET Recipient does not support any of the languages included in the header, the SET Recipient MUST respond with messages that are understandable by an English-speaking person, as described in Section 4.5 of <a href="#RFC2277" class="xref">[RFC2277]</a>.  </p>
 <div id="rfc.figure.3"></div>
 <div id="errorResponseInvalidKey"></div>
 <p>The following is an example non-normative error response indicating that the key used to encrypt the SET has been revoked.</p>
 <pre>HTTP/1.1 400 Bad Request
+Content-Language: en-US
 Content-Type: application/json
 
 {
@@ -660,6 +664,7 @@ Content-Type: application/json
 <div id="errorResponseExpiredToken"></div>
 <p>The following is an example non-normative error response indicating that the access token included in the request is expired.</p>
 <pre>HTTP/1.1 400 Bad Request
+Content-Language: en-US
 Content-Type: application/json
 
 {
@@ -671,6 +676,7 @@ Content-Type: application/json
 <div id="errorResponseBadIssuer"></div>
 <p>The following is an example non-normative error response indicating that the SET Transmitter is not permitted to transmit SETs issued by the issuer specified in the SET.</p>
 <pre>HTTP/1.1 400 Bad Request
+Content-Language: en-US
 Content-Type: application/json
 
 {
@@ -838,6 +844,11 @@ Content-Type: application/json
 <a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
 </tr>
 <tr>
+<td class="reference"><b id="RFC2277">[RFC2277]</b></td>
+<td class="top">
+<a>Alvestrand, H.</a>, "<a href="http://tools.ietf.org/html/rfc2277">IETF Policy on Character Sets and Languages</a>", BCP 18, RFC 2277, DOI 10.17487/RFC2277, January 1998.</td>
+</tr>
+<tr>
 <td class="reference"><b id="RFC5246">[RFC5246]</b></td>
 <td class="top">
 <a>Dierks, T.</a> and <a>E. Rescorla</a>, "<a href="http://tools.ietf.org/html/rfc5246">The Transport Layer Security (TLS) Protocol Version 1.2</a>", RFC 5246, DOI 10.17487/RFC5246, August 2008.</td>
@@ -998,6 +1009,8 @@ Content-Type: application/json
 <li>Removed un-referenced normative references.</li>
 <li>Added normative reference to JSON in error response definition.</li>
 <li>Added text clarifying that the value of the <samp>description</samp> attribute in error responses is implementation specific.  </li>
+<li>Added requirement that error descriptions and responses are UTF-8 encoded.</li>
+<li>Added error description language preferences and specification via <samp>Accept-Language</samp> and <samp>Content-Language</samp> headers.  </li>
 </ul>
 
 <p> </p>

--- a/draft-ietf-secevent-http-push.html
+++ b/draft-ietf-secevent-http-push.html
@@ -403,12 +403,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.11.1 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.7.0 - http://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Backman, A., Ed., Jones, M., Ed., Scurtescu, M., Ansari, M., and A. Nadalin" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-secevent-http-push-03" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-18" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-12-6" />
   <meta name="dct.abstract" content="This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST reqest to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  " />
   <meta name="description" content="This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST reqest to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  " />
 
@@ -432,7 +432,7 @@
 <td class="right">M. Jones, Ed.</td>
 </tr>
 <tr>
-<td class="left">Expires: April 21, 2019</td>
+<td class="left">Expires: June 9, 2019</td>
 <td class="right">Microsoft</td>
 </tr>
 <tr>
@@ -461,7 +461,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">October 18, 2018</td>
+<td class="right">December 6, 2018</td>
 </tr>
 
     	
@@ -475,12 +475,12 @@
 <p>This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST reqest to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  </p>
 <h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
-<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on April 21, 2019.</p>
+<p>This Internet-Draft will expire on June 9, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
-<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
   <hr class="noprint" />
@@ -635,32 +635,53 @@ tZSI6Impkb2UiLCJpZCI6IjQ0ZjYxNDJkZjk2YmQ2YWI2MWU3NTIxZDkiLCJuYW
 <a href="#rfc.section.2.3">2.3.</a> <a href="#failureResponse" id="failureResponse">Failure Response</a>
 </h1>
 <p id="rfc.section.2.3.p.1">In the event of a general HTTP error condition, the SET Recipient MAY respond with an appropriate HTTP Status Code as defined in Section 6 of <a href="#RFC7231" class="xref">[RFC7231]</a>.</p>
-<p id="rfc.section.2.3.p.2">When the SET Recipient detects an error parsing or validating a SET transmitted in a SET Transmission Request, the SET Recipient SHALL respond with an HTTP Response Status Code of 400 (Bad Request).  The <samp>Content-Type</samp> header of this response MUST be "application/json", and the body MUST be a JSON object containing the following name/value pairs: </p>
+<p id="rfc.section.2.3.p.2">When the SET Recipient detects an error parsing or validating a SET transmitted in a SET Transmission Request, the SET Recipient SHALL respond with an HTTP Response Status Code of 400 (Bad Request).  The <samp>Content-Type</samp> header of this response MUST be "application/json", and the body MUST be a <a href="#RFC7159" class="xref">JSON</a> object containing the following name/value pairs: </p>
 
 <dl>
 <dt>err</dt>
 <dd style="margin-left: 8">A Security Event Token Error Code (see <a href="#error_codes" class="xref">Section 2.4</a>).  </dd>
 <dt>description</dt>
-<dd style="margin-left: 8">Human-readable text that describes the error and MAY contain additional diagnostic information.  </dd>
+<dd style="margin-left: 8">Human-readable text that describes the error and MAY contain additional diagnostic information. The exact content of this field is implementation-specific.  </dd>
 </dl>
 
 <p> </p>
 <div id="rfc.figure.3"></div>
-<div id="badPostResponse"></div>
-<p>The following is an example non-normative error response.</p>
+<div id="errorResponseInvalidKey"></div>
+<p>The following is an example non-normative error response indicating that the key used to encrypt the SET has been revoked.</p>
 <pre>HTTP/1.1 400 Bad Request
 Content-Type: application/json
 
 {
-"err":"dup",
-"description":"SET already received. Ignored."
-
+  "err": "invalid_key",
+  "description": "Key ID 12345 has been revoked."
 }</pre>
-<p class="figure">Figure 3: Example Error Response</p>
+<p class="figure">Figure 3: Example Error Response (invalid_key)</p>
+<div id="rfc.figure.4"></div>
+<div id="errorResponseExpiredToken"></div>
+<p>The following is an example non-normative error response indicating that the access token included in the request is expired.</p>
+<pre>HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "err": "authentication_failed",
+  "description": "Access token is expired."
+}</pre>
+<p class="figure">Figure 4: Example Error Response (authentication_failed)</p>
+<div id="rfc.figure.5"></div>
+<div id="errorResponseBadIssuer"></div>
+<p>The following is an example non-normative error response indicating that the SET Transmitter is not permitted to transmit SETs issued by the issuer specified in the SET.</p>
+<pre>HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "err": "access_denied",
+  "description": "Not authorized for issuer http://iss.example.com/."
+}</pre>
+<p class="figure">Figure 5: Example Error Response (access_denied)</p>
 <h1 id="rfc.section.2.4">
 <a href="#rfc.section.2.4">2.4.</a> <a href="#error_codes" id="error_codes">Security Event Token Delivery Error Codes</a>
 </h1>
-<p id="rfc.section.2.4.p.1">Security Event Token Delivery Error Codes are strings that identify a specific type of error that may occur when parsing or validating a SET.  Every Security Event Token Delivery Error Code MUST have a unique name registered in the IANA "Security Event Token Delivery Error Codes" registry established by <a href="#iana_set_errors" class="xref">Section 7.1</a>.</p>
+<p id="rfc.section.2.4.p.1">Security Event Token Delivery Error Codes are strings that identify a specific category of error that may occur when parsing or validating a SET.  Every Security Event Token Delivery Error Code MUST have a unique name registered in the IANA "Security Event Token Delivery Error Codes" registry established by <a href="#iana_set_errors" class="xref">Section 7.1</a>.</p>
 <p id="rfc.section.2.4.p.2">The following table presents the initial set of Error Codes that are registered in the IANA "Security Event Token Delivery Error Codes" registry:</p>
 <div id="rfc.table.1"></div>
 <div id="reqErrors"></div>
@@ -672,52 +693,20 @@ Content-Type: application/json
 </tr></thead>
 <tbody>
 <tr>
-<td class="left">json</td>
-<td class="left">Invalid JSON object.</td>
+<td class="left">invalid_request</td>
+<td class="left">The request body cannot be parsed as a SET, or the event payload within the SET does not conform to the event's definition.</td>
 </tr>
 <tr>
-<td class="left">jwtParse</td>
-<td class="left">Invalid or unparsable JWT or JSON structure.</td>
+<td class="left">invalid_key</td>
+<td class="left">One or more keys used to encrypt or sign the SET is invalid or otherwise unacceptable to the SET Recipient. (e.g., expired, revoked, failed certificate validation, etc.)</td>
 </tr>
 <tr>
-<td class="left">jwtHdr</td>
-<td class="left">An invalid JWT header was detected.</td>
+<td class="left">authentication_failed</td>
+<td class="left">The SET Recipient could not authenticate the SET Transmitter from the contents of the request.</td>
 </tr>
 <tr>
-<td class="left">jwtCrypto</td>
-<td class="left">Unable to parse due to unsupported algorithm.</td>
-</tr>
-<tr>
-<td class="left">jws</td>
-<td class="left">Signature was not validated.</td>
-</tr>
-<tr>
-<td class="left">jwe</td>
-<td class="left">Unable to decrypt JWE encoded data.</td>
-</tr>
-<tr>
-<td class="left">jwtAud</td>
-<td class="left">Invalid audience value.</td>
-</tr>
-<tr>
-<td class="left">jwtIss</td>
-<td class="left">Issuer not recognized.</td>
-</tr>
-<tr>
-<td class="left">setType</td>
-<td class="left">An unexpected Event type was received.</td>
-</tr>
-<tr>
-<td class="left">setParse</td>
-<td class="left">Invalid structure was encountered such as an inability to parse or an incomplete set of Event claims.</td>
-</tr>
-<tr>
-<td class="left">setData</td>
-<td class="left">SET claims incomplete or invalid.</td>
-</tr>
-<tr>
-<td class="left">dup</td>
-<td class="left">A duplicate SET was received and has been ignored.</td>
+<td class="left">access_denied</td>
+<td class="left">The SET Transmitter is not authorized to transmit the provided SET to the SET Recipient.</td>
 </tr>
 </tbody>
 </table>
@@ -729,7 +718,7 @@ Content-Type: application/json
 <h1 id="rfc.section.4">
 <a href="#rfc.section.4">4.</a> <a href="#reliability" id="reliability">Delivery Reliability</a>
 </h1>
-<p id="rfc.section.4.p.1">Delivery reliability requirements may vary from implementation to implementation.  This specification defines the response from the SET Recipient in such a way as to provide the SET Transmitter with the information necessary to determine what further action is required, if any, in order to meet their requirements.  SET Transmitters with high reliability requirements may be tempted to always retry failed transmissions, however it should be noted that for many types of SET delivery errors, a retry is extremely unlikely to be successful.  For example, <samp>json</samp>, <samp>jwtParse</samp>, and <samp>setParse</samp> all indicate structural errors in the content of the SET that are likely to remain when re-transmitting the same SET.  Others such as <samp>jws</samp> or <samp>jwe</samp> may be transient, for example if cryptographic material has not been properly distributed to the SET Recipient's systems.  </p>
+<p id="rfc.section.4.p.1">Delivery reliability requirements may vary from implementation to implementation.  This specification defines the response from the SET Recipient in such a way as to provide the SET Transmitter with the information necessary to determine what further action is required, if any, in order to meet their requirements.  SET Transmitters with high reliability requirements may be tempted to always retry failed transmissions, however it should be noted that for many types of SET delivery errors, a retry is extremely unlikely to be successful.  For example, <samp>invalid_request</samp> indicates a structural error in the content of the request body that is likely to remain when re-transmitting the same SET.  Others such as <samp>access_denied</samp> may be transient, for example if the SET Transmitter refreshes expired credentials prior to re-transmission.  </p>
 <p id="rfc.section.4.p.2">Implementers SHOULD evaluate their reliability requirements and the impact of various retry mechanisms on the performance of their systems to determine the correct strategy for various error conditions.  </p>
 <h1 id="rfc.section.5">
 <a href="#rfc.section.5">5.</a> <a href="#Security" id="Security">Security Considerations</a>
@@ -786,23 +775,9 @@ Content-Type: application/json
 
 <dl>
 <dt></dt>
-<dd style="margin-left: 8">Error Code: json</dd>
+<dd style="margin-left: 8">Error Code: invalid_request</dd>
 <dt></dt>
-<dd style="margin-left: 8">Description: Invalid JSON object</dd>
-<dt></dt>
-<dd style="margin-left: 8">Change Controller: IETF Secevent Working Group</dd>
-<dt></dt>
-<dd style="margin-left: 8">Defining Document(s): <a href="#error_codes" class="xref">Section 2.4</a> of this document </dd>
-</dl>
-
-<p> </p>
-<p></p>
-
-<dl>
-<dt></dt>
-<dd style="margin-left: 8">Error Code: jwtParse</dd>
-<dt></dt>
-<dd style="margin-left: 8">Description: Invalid or unparsable JWT or JSON structure</dd>
+<dd style="margin-left: 8">Description: The request body cannot be parsed as a SET, or the event payload within the SET does not conform to the event's definition.</dd>
 <dt></dt>
 <dd style="margin-left: 8">Change Controller: IETF Secevent Working Group</dd>
 <dt></dt>
@@ -814,23 +789,9 @@ Content-Type: application/json
 
 <dl>
 <dt></dt>
-<dd style="margin-left: 8">Error Code: jwtHdr</dd>
+<dd style="margin-left: 8">Error Code: invalid_key</dd>
 <dt></dt>
-<dd style="margin-left: 8">Description: An invalid JWT header was detected</dd>
-<dt></dt>
-<dd style="margin-left: 8">Change Controller: IETF Secevent Working Group</dd>
-<dt></dt>
-<dd style="margin-left: 8">Defining Document(s): <a href="#error_codes" class="xref">Section 2.4</a> of this document </dd>
-</dl>
-
-<p> </p>
-<p></p>
-
-<dl>
-<dt></dt>
-<dd style="margin-left: 8">Error Code: jwtCrypto</dd>
-<dt></dt>
-<dd style="margin-left: 8">Description: Unable to parse due to unsupported algorithm</dd>
+<dd style="margin-left: 8">Description: One or more keys used to encrypt or sign the SET is invalid or otherwise unacceptable to the SET Recipient. (e.g., expired, revoked, failed certificate validation, etc.)</dd>
 <dt></dt>
 <dd style="margin-left: 8">Change Controller: IETF Secevent Working Group</dd>
 <dt></dt>
@@ -842,23 +803,9 @@ Content-Type: application/json
 
 <dl>
 <dt></dt>
-<dd style="margin-left: 8">Error Code: jws</dd>
+<dd style="margin-left: 8">Error Code: authentication_failed</dd>
 <dt></dt>
-<dd style="margin-left: 8">Description: Signature was not validated</dd>
-<dt></dt>
-<dd style="margin-left: 8">Change Controller: IETF Secevent Working Group</dd>
-<dt></dt>
-<dd style="margin-left: 8">Defining Document(s): <a href="#error_codes" class="xref">Section 2.4</a> of this document </dd>
-</dl>
-
-<p> </p>
-<p></p>
-
-<dl>
-<dt></dt>
-<dd style="margin-left: 8">Error Code: jwe</dd>
-<dt></dt>
-<dd style="margin-left: 8">Description: Unable to decrypt JWE encoded data</dd>
+<dd style="margin-left: 8">Description: The SET Recipient could not authenticate the SET Transmitter from the contents of the request.</dd>
 <dt></dt>
 <dd style="margin-left: 8">Change Controller: IETF Secevent Working Group</dd>
 <dt></dt>
@@ -870,79 +817,9 @@ Content-Type: application/json
 
 <dl>
 <dt></dt>
-<dd style="margin-left: 8">Error Code: jwtAud</dd>
+<dd style="margin-left: 8">Error Code: access_denied</dd>
 <dt></dt>
-<dd style="margin-left: 8">Description: Invalid audience value</dd>
-<dt></dt>
-<dd style="margin-left: 8">Change Controller: IETF Secevent Working Group</dd>
-<dt></dt>
-<dd style="margin-left: 8">Defining Document(s): <a href="#error_codes" class="xref">Section 2.4</a> of this document </dd>
-</dl>
-
-<p> </p>
-<p></p>
-
-<dl>
-<dt></dt>
-<dd style="margin-left: 8">Error Code: jwtIss</dd>
-<dt></dt>
-<dd style="margin-left: 8">Description: Issuer not recognized</dd>
-<dt></dt>
-<dd style="margin-left: 8">Change Controller: </dd>
-<dt></dt>
-<dd style="margin-left: 8">Defining Document(s): <a href="#error_codes" class="xref">Section 2.4</a> of this document </dd>
-</dl>
-
-<p> </p>
-<p></p>
-
-<dl>
-<dt></dt>
-<dd style="margin-left: 8">Error Code: setType</dd>
-<dt></dt>
-<dd style="margin-left: 8">Description: An unexpected Event type was received</dd>
-<dt></dt>
-<dd style="margin-left: 8">Change Controller: IETF Secevent Working Group</dd>
-<dt></dt>
-<dd style="margin-left: 8">Defining Document(s): <a href="#error_codes" class="xref">Section 2.4</a> of this document </dd>
-</dl>
-
-<p> </p>
-<p></p>
-
-<dl>
-<dt></dt>
-<dd style="margin-left: 8">Error Code: setParse</dd>
-<dt></dt>
-<dd style="margin-left: 8">Description: Invalid structure was encountered such as an inability to parse or an incomplete set of Event claims.  </dd>
-<dt></dt>
-<dd style="margin-left: 8">Change Controller: IETF Secevent Working Group</dd>
-<dt></dt>
-<dd style="margin-left: 8">Defining Document(s): <a href="#error_codes" class="xref">Section 2.4</a> of this document </dd>
-</dl>
-
-<p> </p>
-<p></p>
-
-<dl>
-<dt></dt>
-<dd style="margin-left: 8">Error Code: setData</dd>
-<dt></dt>
-<dd style="margin-left: 8">Description: SET claims incomplete or invalid</dd>
-<dt></dt>
-<dd style="margin-left: 8">Change Controller: IETF Secevent Working Group</dd>
-<dt></dt>
-<dd style="margin-left: 8">Defining Document(s): <a href="#error_codes" class="xref">Section 2.4</a> of this document </dd>
-</dl>
-
-<p> </p>
-<p></p>
-
-<dl>
-<dt></dt>
-<dd style="margin-left: 8">Error Code: dup</dd>
-<dt></dt>
-<dd style="margin-left: 8">Description:  A duplicate SET was received and has been ignored.  </dd>
+<dd style="margin-left: 8">Description: The SET Transmitter is not authorized to transmit the provided SET to the SET Recipient.</dd>
 <dt></dt>
 <dd style="margin-left: 8">Change Controller: IETF Secevent Working Group</dd>
 <dt></dt>
@@ -958,118 +835,71 @@ Content-Type: application/json
 <tr>
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
 <td class="top">
-<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
-</tr>
-<tr>
-<td class="reference"><b id="RFC3986">[RFC3986]</b></td>
-<td class="top">
-<a>Berners-Lee, T.</a>, <a>Fielding, R.</a> and <a>L. Masinter</a>, "<a href="https://tools.ietf.org/html/rfc3986">Uniform Resource Identifier (URI): Generic Syntax</a>", STD 66, RFC 3986, DOI 10.17487/RFC3986, January 2005.</td>
+<a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC5246">[RFC5246]</b></td>
 <td class="top">
-<a>Dierks, T.</a> and <a>E. Rescorla</a>, "<a href="https://tools.ietf.org/html/rfc5246">The Transport Layer Security (TLS) Protocol Version 1.2</a>", RFC 5246, DOI 10.17487/RFC5246, August 2008.</td>
-</tr>
-<tr>
-<td class="reference"><b id="RFC5988">[RFC5988]</b></td>
-<td class="top">
-<a>Nottingham, M.</a>, "<a href="https://tools.ietf.org/html/rfc5988">Web Linking</a>", RFC 5988, DOI 10.17487/RFC5988, October 2010.</td>
+<a>Dierks, T.</a> and <a>E. Rescorla</a>, "<a href="http://tools.ietf.org/html/rfc5246">The Transport Layer Security (TLS) Protocol Version 1.2</a>", RFC 5246, DOI 10.17487/RFC5246, August 2008.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC6125">[RFC6125]</b></td>
 <td class="top">
-<a>Saint-Andre, P.</a> and <a>J. Hodges</a>, "<a href="https://tools.ietf.org/html/rfc6125">Representation and Verification of Domain-Based Application Service Identity within Internet Public Key Infrastructure Using X.509 (PKIX) Certificates in the Context of Transport Layer Security (TLS)</a>", RFC 6125, DOI 10.17487/RFC6125, March 2011.</td>
+<a>Saint-Andre, P.</a> and <a>J. Hodges</a>, "<a href="http://tools.ietf.org/html/rfc6125">Representation and Verification of Domain-Based Application Service Identity within Internet Public Key Infrastructure Using X.509 (PKIX) Certificates in the Context of Transport Layer Security (TLS)</a>", RFC 6125, DOI 10.17487/RFC6125, March 2011.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC7159">[RFC7159]</b></td>
 <td class="top">
-<a>Bray, T.</a>, "<a href="https://tools.ietf.org/html/rfc7159">The JavaScript Object Notation (JSON) Data Interchange Format</a>", RFC 7159, DOI 10.17487/RFC7159, March 2014.</td>
+<a>Bray, T.</a>, "<a href="http://tools.ietf.org/html/rfc7159">The JavaScript Object Notation (JSON) Data Interchange Format</a>", RFC 7159, DOI 10.17487/RFC7159, March 2014.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC7231">[RFC7231]</b></td>
 <td class="top">
-<a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="https://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>", RFC 7231, DOI 10.17487/RFC7231, June 2014.</td>
+<a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="http://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>", RFC 7231, DOI 10.17487/RFC7231, June 2014.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC7515">[RFC7515]</b></td>
 <td class="top">
-<a>Jones, M.</a>, <a>Bradley, J.</a> and <a>N. Sakimura</a>, "<a href="https://tools.ietf.org/html/rfc7515">JSON Web Signature (JWS)</a>", RFC 7515, DOI 10.17487/RFC7515, May 2015.</td>
+<a>Jones, M.</a>, <a>Bradley, J.</a> and <a>N. Sakimura</a>, "<a href="http://tools.ietf.org/html/rfc7515">JSON Web Signature (JWS)</a>", RFC 7515, DOI 10.17487/RFC7515, May 2015.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC7516">[RFC7516]</b></td>
 <td class="top">
-<a>Jones, M.</a> and <a>J. Hildebrand</a>, "<a href="https://tools.ietf.org/html/rfc7516">JSON Web Encryption (JWE)</a>", RFC 7516, DOI 10.17487/RFC7516, May 2015.</td>
-</tr>
-<tr>
-<td class="reference"><b id="RFC7517">[RFC7517]</b></td>
-<td class="top">
-<a>Jones, M.</a>, "<a href="https://tools.ietf.org/html/rfc7517">JSON Web Key (JWK)</a>", RFC 7517, DOI 10.17487/RFC7517, May 2015.</td>
+<a>Jones, M.</a> and <a>J. Hildebrand</a>, "<a href="http://tools.ietf.org/html/rfc7516">JSON Web Encryption (JWE)</a>", RFC 7516, DOI 10.17487/RFC7516, May 2015.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC7519">[RFC7519]</b></td>
 <td class="top">
-<a>Jones, M.</a>, <a>Bradley, J.</a> and <a>N. Sakimura</a>, "<a href="https://tools.ietf.org/html/rfc7519">JSON Web Token (JWT)</a>", RFC 7519, DOI 10.17487/RFC7519, May 2015.</td>
+<a>Jones, M.</a>, <a>Bradley, J.</a> and <a>N. Sakimura</a>, "<a href="http://tools.ietf.org/html/rfc7519">JSON Web Token (JWT)</a>", RFC 7519, DOI 10.17487/RFC7519, May 2015.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC7525">[RFC7525]</b></td>
 <td class="top">
-<a>Sheffer, Y.</a>, <a>Holz, R.</a> and <a>P. Saint-Andre</a>, "<a href="https://tools.ietf.org/html/rfc7525">Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)</a>", BCP 195, RFC 7525, DOI 10.17487/RFC7525, May 2015.</td>
+<a>Sheffer, Y.</a>, <a>Holz, R.</a> and <a>P. Saint-Andre</a>, "<a href="http://tools.ietf.org/html/rfc7525">Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)</a>", BCP 195, RFC 7525, DOI 10.17487/RFC7525, May 2015.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC8126">[RFC8126]</b></td>
 <td class="top">
-<a>Cotton, M.</a>, <a>Leiba, B.</a> and <a>T. Narten</a>, "<a href="https://tools.ietf.org/html/rfc8126">Guidelines for Writing an IANA Considerations Section in RFCs</a>", BCP 26, RFC 8126, DOI 10.17487/RFC8126, June 2017.</td>
+<a>Cotton, M.</a>, <a>Leiba, B.</a> and <a>T. Narten</a>, "<a href="http://tools.ietf.org/html/rfc8126">Guidelines for Writing an IANA Considerations Section in RFCs</a>", BCP 26, RFC 8126, DOI 10.17487/RFC8126, June 2017.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC8174">[RFC8174]</b></td>
 <td class="top">
-<a>Leiba, B.</a>, "<a href="https://tools.ietf.org/html/rfc8174">Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</a>", BCP 14, RFC 8174, DOI 10.17487/RFC8174, May 2017.</td>
+<a>Leiba, B.</a>, "<a href="http://tools.ietf.org/html/rfc8174">Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</a>", BCP 14, RFC 8174, DOI 10.17487/RFC8174, May 2017.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC8417">[RFC8417]</b></td>
 <td class="top">
-<a>Hunt, P.</a>, <a>Jones, M.</a>, <a>Denniss, W.</a> and <a>M. Ansari</a>, "<a href="https://tools.ietf.org/html/rfc8417">Security Event Token (SET)</a>", RFC 8417, DOI 10.17487/RFC8417, July 2018.</td>
+<a>Hunt, P.</a>, <a>Jones, M.</a>, <a>Denniss, W.</a> and <a>M. Ansari</a>, "<a href="http://tools.ietf.org/html/rfc8417">Security Event Token (SET)</a>", RFC 8417, DOI 10.17487/RFC8417, July 2018.</td>
 </tr>
 </tbody></table>
 <h1 id="rfc.references.2">
 <a href="#rfc.references.2">8.2.</a> Informative References</h1>
-<table><tbody>
-<tr>
-<td class="reference"><b id="RFC3339">[RFC3339]</b></td>
-<td class="top">
-<a>Klyne, G.</a> and <a>C. Newman</a>, "<a href="https://tools.ietf.org/html/rfc3339">Date and Time on the Internet: Timestamps</a>", RFC 3339, DOI 10.17487/RFC3339, July 2002.</td>
-</tr>
-<tr>
-<td class="reference"><b id="RFC6749">[RFC6749]</b></td>
-<td class="top">
-<a>Hardt, D.</a>, "<a href="https://tools.ietf.org/html/rfc6749">The OAuth 2.0 Authorization Framework</a>", RFC 6749, DOI 10.17487/RFC6749, October 2012.</td>
-</tr>
-<tr>
-<td class="reference"><b id="RFC6750">[RFC6750]</b></td>
-<td class="top">
-<a>Jones, M.</a> and <a>D. Hardt</a>, "<a href="https://tools.ietf.org/html/rfc6750">The OAuth 2.0 Authorization Framework: Bearer Token Usage</a>", RFC 6750, DOI 10.17487/RFC6750, October 2012.</td>
-</tr>
-<tr>
-<td class="reference"><b id="RFC7230">[RFC7230]</b></td>
-<td class="top">
-<a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="https://tools.ietf.org/html/rfc7230">Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</a>", RFC 7230, DOI 10.17487/RFC7230, June 2014.</td>
-</tr>
-<tr>
+<table><tbody><tr>
 <td class="reference"><b id="RFC7235">[RFC7235]</b></td>
 <td class="top">
-<a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="https://tools.ietf.org/html/rfc7235">Hypertext Transfer Protocol (HTTP/1.1): Authentication</a>", RFC 7235, DOI 10.17487/RFC7235, June 2014.</td>
-</tr>
-<tr>
-<td class="reference"><b id="RFC7521">[RFC7521]</b></td>
-<td class="top">
-<a>Campbell, B.</a>, <a>Mortimore, C.</a>, <a>Jones, M.</a> and <a>Y. Goland</a>, "<a href="https://tools.ietf.org/html/rfc7521">Assertion Framework for OAuth 2.0 Client Authentication and Authorization Grants</a>", RFC 7521, DOI 10.17487/RFC7521, May 2015.</td>
-</tr>
-<tr>
-<td class="reference"><b id="RFC7617">[RFC7617]</b></td>
-<td class="top">
-<a>Reschke, J.</a>, "<a href="https://tools.ietf.org/html/rfc7617">The 'Basic' HTTP Authentication Scheme</a>", RFC 7617, DOI 10.17487/RFC7617, September 2015.</td>
-</tr>
-</tbody></table>
+<a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="http://tools.ietf.org/html/rfc7235">Hypertext Transfer Protocol (HTTP/1.1): Authentication</a>", RFC 7235, DOI 10.17487/RFC7235, June 2014.</td>
+</tr></tbody></table>
 <h1 id="rfc.appendix.A">
 <a href="#rfc.appendix.A">Appendix A.</a> Other Streaming Specifications</h1>
 <p id="rfc.section.A.p.1">[[EDITORS NOTE: This section to be removed prior to publication]]</p>
@@ -1157,6 +987,17 @@ Content-Type: application/json
 <li>Changes to align terminology with RFC 8417, for instance, by using the already defined term SET Recipient rather than SET Receiver.  </li>
 <li>Applied editorial and minor normative corrections.  </li>
 <li>Updated Marius' contact information.  </li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.C.p.5">Draft 04 - AB: </p>
+
+<ul>
+<li>Replaced Error Codes with smaller set of meaningfully differentiated codes.</li>
+<li>Added more error response examples.</li>
+<li>Removed un-referenced normative references.</li>
+<li>Added normative reference to JSON in error response definition.</li>
+<li>Added text clarifying that the value of the <samp>description</samp> attribute in error responses is implementation specific.  </li>
 </ul>
 
 <p> </p>

--- a/draft-ietf-secevent-http-push.html
+++ b/draft-ietf-secevent-http-push.html
@@ -403,12 +403,12 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.7.0 - http://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.15.3 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Backman, A., Ed., Jones, M., Ed., Scurtescu, M., Ansari, M., and A. Nadalin" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-secevent-http-push-03" />
-  <meta name="dct.issued" scheme="ISO8601" content="2018-12-6" />
+  <meta name="dct.issued" scheme="ISO8601" content="2018-10" />
   <meta name="dct.abstract" content="This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST reqest to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  " />
   <meta name="description" content="This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST reqest to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  " />
 
@@ -432,7 +432,7 @@
 <td class="right">M. Jones, Ed.</td>
 </tr>
 <tr>
-<td class="left">Expires: June 9, 2019</td>
+<td class="left">Expires: June 13, 2019</td>
 <td class="right">Microsoft</td>
 </tr>
 <tr>
@@ -461,7 +461,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">December 6, 2018</td>
+<td class="right">December 10, 2018</td>
 </tr>
 
     	
@@ -475,12 +475,12 @@
 <p>This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST reqest to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  </p>
 <h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
-<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at http://datatracker.ietf.org/drafts/current/.</p>
+<p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on June 9, 2019.</p>
+<p>This Internet-Draft will expire on June 13, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2018 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
-<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (http://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
+<p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
 
   
   <hr class="noprint" />
@@ -841,67 +841,67 @@ Content-Type: application/json
 <tr>
 <td class="reference"><b id="RFC2119">[RFC2119]</b></td>
 <td class="top">
-<a>Bradner, S.</a>, "<a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
+<a>Bradner, S.</a>, "<a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC2277">[RFC2277]</b></td>
 <td class="top">
-<a>Alvestrand, H.</a>, "<a href="http://tools.ietf.org/html/rfc2277">IETF Policy on Character Sets and Languages</a>", BCP 18, RFC 2277, DOI 10.17487/RFC2277, January 1998.</td>
+<a>Alvestrand, H.</a>, "<a href="https://tools.ietf.org/html/rfc2277">IETF Policy on Character Sets and Languages</a>", BCP 18, RFC 2277, DOI 10.17487/RFC2277, January 1998.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC5246">[RFC5246]</b></td>
 <td class="top">
-<a>Dierks, T.</a> and <a>E. Rescorla</a>, "<a href="http://tools.ietf.org/html/rfc5246">The Transport Layer Security (TLS) Protocol Version 1.2</a>", RFC 5246, DOI 10.17487/RFC5246, August 2008.</td>
+<a>Dierks, T.</a> and <a>E. Rescorla</a>, "<a href="https://tools.ietf.org/html/rfc5246">The Transport Layer Security (TLS) Protocol Version 1.2</a>", RFC 5246, DOI 10.17487/RFC5246, August 2008.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC6125">[RFC6125]</b></td>
 <td class="top">
-<a>Saint-Andre, P.</a> and <a>J. Hodges</a>, "<a href="http://tools.ietf.org/html/rfc6125">Representation and Verification of Domain-Based Application Service Identity within Internet Public Key Infrastructure Using X.509 (PKIX) Certificates in the Context of Transport Layer Security (TLS)</a>", RFC 6125, DOI 10.17487/RFC6125, March 2011.</td>
+<a>Saint-Andre, P.</a> and <a>J. Hodges</a>, "<a href="https://tools.ietf.org/html/rfc6125">Representation and Verification of Domain-Based Application Service Identity within Internet Public Key Infrastructure Using X.509 (PKIX) Certificates in the Context of Transport Layer Security (TLS)</a>", RFC 6125, DOI 10.17487/RFC6125, March 2011.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC7159">[RFC7159]</b></td>
 <td class="top">
-<a>Bray, T.</a>, "<a href="http://tools.ietf.org/html/rfc7159">The JavaScript Object Notation (JSON) Data Interchange Format</a>", RFC 7159, DOI 10.17487/RFC7159, March 2014.</td>
+<a>Bray, T.</a>, "<a href="https://tools.ietf.org/html/rfc7159">The JavaScript Object Notation (JSON) Data Interchange Format</a>", RFC 7159, DOI 10.17487/RFC7159, March 2014.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC7231">[RFC7231]</b></td>
 <td class="top">
-<a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="http://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>", RFC 7231, DOI 10.17487/RFC7231, June 2014.</td>
+<a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="https://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a>", RFC 7231, DOI 10.17487/RFC7231, June 2014.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC7515">[RFC7515]</b></td>
 <td class="top">
-<a>Jones, M.</a>, <a>Bradley, J.</a> and <a>N. Sakimura</a>, "<a href="http://tools.ietf.org/html/rfc7515">JSON Web Signature (JWS)</a>", RFC 7515, DOI 10.17487/RFC7515, May 2015.</td>
+<a>Jones, M.</a>, <a>Bradley, J.</a> and <a>N. Sakimura</a>, "<a href="https://tools.ietf.org/html/rfc7515">JSON Web Signature (JWS)</a>", RFC 7515, DOI 10.17487/RFC7515, May 2015.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC7516">[RFC7516]</b></td>
 <td class="top">
-<a>Jones, M.</a> and <a>J. Hildebrand</a>, "<a href="http://tools.ietf.org/html/rfc7516">JSON Web Encryption (JWE)</a>", RFC 7516, DOI 10.17487/RFC7516, May 2015.</td>
+<a>Jones, M.</a> and <a>J. Hildebrand</a>, "<a href="https://tools.ietf.org/html/rfc7516">JSON Web Encryption (JWE)</a>", RFC 7516, DOI 10.17487/RFC7516, May 2015.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC7519">[RFC7519]</b></td>
 <td class="top">
-<a>Jones, M.</a>, <a>Bradley, J.</a> and <a>N. Sakimura</a>, "<a href="http://tools.ietf.org/html/rfc7519">JSON Web Token (JWT)</a>", RFC 7519, DOI 10.17487/RFC7519, May 2015.</td>
+<a>Jones, M.</a>, <a>Bradley, J.</a> and <a>N. Sakimura</a>, "<a href="https://tools.ietf.org/html/rfc7519">JSON Web Token (JWT)</a>", RFC 7519, DOI 10.17487/RFC7519, May 2015.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC7525">[RFC7525]</b></td>
 <td class="top">
-<a>Sheffer, Y.</a>, <a>Holz, R.</a> and <a>P. Saint-Andre</a>, "<a href="http://tools.ietf.org/html/rfc7525">Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)</a>", BCP 195, RFC 7525, DOI 10.17487/RFC7525, May 2015.</td>
+<a>Sheffer, Y.</a>, <a>Holz, R.</a> and <a>P. Saint-Andre</a>, "<a href="https://tools.ietf.org/html/rfc7525">Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS)</a>", BCP 195, RFC 7525, DOI 10.17487/RFC7525, May 2015.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC8126">[RFC8126]</b></td>
 <td class="top">
-<a>Cotton, M.</a>, <a>Leiba, B.</a> and <a>T. Narten</a>, "<a href="http://tools.ietf.org/html/rfc8126">Guidelines for Writing an IANA Considerations Section in RFCs</a>", BCP 26, RFC 8126, DOI 10.17487/RFC8126, June 2017.</td>
+<a>Cotton, M.</a>, <a>Leiba, B.</a> and <a>T. Narten</a>, "<a href="https://tools.ietf.org/html/rfc8126">Guidelines for Writing an IANA Considerations Section in RFCs</a>", BCP 26, RFC 8126, DOI 10.17487/RFC8126, June 2017.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC8174">[RFC8174]</b></td>
 <td class="top">
-<a>Leiba, B.</a>, "<a href="http://tools.ietf.org/html/rfc8174">Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</a>", BCP 14, RFC 8174, DOI 10.17487/RFC8174, May 2017.</td>
+<a>Leiba, B.</a>, "<a href="https://tools.ietf.org/html/rfc8174">Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</a>", BCP 14, RFC 8174, DOI 10.17487/RFC8174, May 2017.</td>
 </tr>
 <tr>
 <td class="reference"><b id="RFC8417">[RFC8417]</b></td>
 <td class="top">
-<a>Hunt, P.</a>, <a>Jones, M.</a>, <a>Denniss, W.</a> and <a>M. Ansari</a>, "<a href="http://tools.ietf.org/html/rfc8417">Security Event Token (SET)</a>", RFC 8417, DOI 10.17487/RFC8417, July 2018.</td>
+<a>Hunt, P.</a>, <a>Jones, M.</a>, <a>Denniss, W.</a> and <a>M. Ansari</a>, "<a href="https://tools.ietf.org/html/rfc8417">Security Event Token (SET)</a>", RFC 8417, DOI 10.17487/RFC8417, July 2018.</td>
 </tr>
 </tbody></table>
 <h1 id="rfc.references.2">
@@ -909,7 +909,7 @@ Content-Type: application/json
 <table><tbody><tr>
 <td class="reference"><b id="RFC7235">[RFC7235]</b></td>
 <td class="top">
-<a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="http://tools.ietf.org/html/rfc7235">Hypertext Transfer Protocol (HTTP/1.1): Authentication</a>", RFC 7235, DOI 10.17487/RFC7235, June 2014.</td>
+<a>Fielding, R.</a> and <a>J. Reschke</a>, "<a href="https://tools.ietf.org/html/rfc7235">Hypertext Transfer Protocol (HTTP/1.1): Authentication</a>", RFC 7235, DOI 10.17487/RFC7235, June 2014.</td>
 </tr></tbody></table>
 <h1 id="rfc.appendix.A">
 <a href="#rfc.appendix.A">Appendix A.</a> Other Streaming Specifications</h1>

--- a/draft-ietf-secevent-http-push.txt
+++ b/draft-ietf-secevent-http-push.txt
@@ -5,14 +5,14 @@
 Security Events Working Group                            A. Backman, Ed.
 Internet-Draft                                                    Amazon
 Intended status: Standards Track                           M. Jones, Ed.
-Expires: June 9, 2019                                          Microsoft
+Expires: June 13, 2019                                         Microsoft
                                                             M. Scurtescu
                                                                 Coinbase
                                                                M. Ansari
                                                                    Cisco
                                                               A. Nadalin
                                                                Microsoft
-                                                        December 6, 2018
+                                                       December 10, 2018
 
 
        Push-Based Security Event Token (SET) Delivery Using HTTP
@@ -34,14 +34,14 @@ Status of This Memo
    Internet-Drafts are working documents of the Internet Engineering
    Task Force (IETF).  Note that other groups may also distribute
    working documents as Internet-Drafts.  The list of current Internet-
-   Drafts is at http://datatracker.ietf.org/drafts/current/.
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
 
    Internet-Drafts are draft documents valid for a maximum of six months
    and may be updated, replaced, or obsoleted by other documents at any
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on June 9, 2019.
+   This Internet-Draft will expire on June 13, 2019.
 
 Copyright Notice
 
@@ -53,12 +53,12 @@ Copyright Notice
 
 
 
-Backman, et al.           Expires June 9, 2019                  [Page 1]
+Backman, et al.           Expires June 13, 2019                 [Page 1]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
-   (http://trustee.ietf.org/license-info) in effect on the date of
+   (https://trustee.ietf.org/license-info) in effect on the date of
    publication of this document.  Please review these documents
    carefully, as they describe your rights and restrictions with respect
    to this document.  Code Components extracted from this document must
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Backman, et al.           Expires June 9, 2019                  [Page 2]
+Backman, et al.           Expires June 13, 2019                 [Page 2]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -165,7 +165,7 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                  [Page 3]
+Backman, et al.           Expires June 13, 2019                 [Page 3]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -221,7 +221,7 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                  [Page 4]
+Backman, et al.           Expires June 13, 2019                 [Page 4]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -277,7 +277,7 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                  [Page 5]
+Backman, et al.           Expires June 13, 2019                 [Page 5]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -333,7 +333,7 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                  [Page 6]
+Backman, et al.           Expires June 13, 2019                 [Page 6]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -389,7 +389,7 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                  [Page 7]
+Backman, et al.           Expires June 13, 2019                 [Page 7]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -445,7 +445,7 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                  [Page 8]
+Backman, et al.           Expires June 13, 2019                 [Page 8]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -501,7 +501,7 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                  [Page 9]
+Backman, et al.           Expires June 13, 2019                 [Page 9]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -557,7 +557,7 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                 [Page 10]
+Backman, et al.           Expires June 13, 2019                [Page 10]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -613,7 +613,7 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                 [Page 11]
+Backman, et al.           Expires June 13, 2019                [Page 11]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -624,8 +624,8 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
-              editor.org/info/rfc2119>.
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
 
    [RFC2277]  Alvestrand, H., "IETF Policy on Character Sets and
               Languages", BCP 18, RFC 2277, DOI 10.17487/RFC2277,
@@ -633,8 +633,8 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
    [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
               (TLS) Protocol Version 1.2", RFC 5246,
-              DOI 10.17487/RFC5246, August 2008, <https://www.rfc-
-              editor.org/info/rfc5246>.
+              DOI 10.17487/RFC5246, August 2008,
+              <https://www.rfc-editor.org/info/rfc5246>.
 
    [RFC6125]  Saint-Andre, P. and J. Hodges, "Representation and
               Verification of Domain-Based Application Service Identity
@@ -649,8 +649,8 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
    [RFC7231]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
               Protocol (HTTP/1.1): Semantics and Content", RFC 7231,
-              DOI 10.17487/RFC7231, June 2014, <https://www.rfc-
-              editor.org/info/rfc7231>.
+              DOI 10.17487/RFC7231, June 2014,
+              <https://www.rfc-editor.org/info/rfc7231>.
 
    [RFC7515]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web
               Signature (JWS)", RFC 7515, DOI 10.17487/RFC7515, May
@@ -669,7 +669,7 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                 [Page 12]
+Backman, et al.           Expires June 13, 2019                [Page 12]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -691,15 +691,15 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
    [RFC8417]  Hunt, P., Ed., Jones, M., Denniss, W., and M. Ansari,
               "Security Event Token (SET)", RFC 8417,
-              DOI 10.17487/RFC8417, July 2018, <https://www.rfc-
-              editor.org/info/rfc8417>.
+              DOI 10.17487/RFC8417, July 2018,
+              <https://www.rfc-editor.org/info/rfc8417>.
 
 8.2.  Informative References
 
    [RFC7235]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
               Protocol (HTTP/1.1): Authentication", RFC 7235,
-              DOI 10.17487/RFC7235, June 2014, <https://www.rfc-
-              editor.org/info/rfc7235>.
+              DOI 10.17487/RFC7235, June 2014,
+              <https://www.rfc-editor.org/info/rfc7235>.
 
 Appendix A.  Other Streaming Specifications
 
@@ -725,7 +725,7 @@ Appendix A.  Other Streaming Specifications
 
 
 
-Backman, et al.           Expires June 9, 2019                 [Page 13]
+Backman, et al.           Expires June 13, 2019                [Page 13]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -781,7 +781,7 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                 [Page 14]
+Backman, et al.           Expires June 13, 2019                [Page 14]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -837,7 +837,7 @@ Appendix C.  Change Log
 
 
 
-Backman, et al.           Expires June 9, 2019                 [Page 15]
+Backman, et al.           Expires June 13, 2019                [Page 15]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -893,7 +893,7 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                 [Page 16]
+Backman, et al.           Expires June 13, 2019                [Page 16]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -949,7 +949,7 @@ Authors' Addresses
 
 
 
-Backman, et al.           Expires June 9, 2019                 [Page 17]
+Backman, et al.           Expires June 13, 2019                [Page 17]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
@@ -1005,4 +1005,4 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                 [Page 18]
+Backman, et al.           Expires June 13, 2019                [Page 18]

--- a/draft-ietf-secevent-http-push.txt
+++ b/draft-ietf-secevent-http-push.txt
@@ -78,23 +78,23 @@ Table of Contents
      2.4.  Security Event Token Delivery Error Codes . . . . . . . .   7
    3.  Authentication and Authorization  . . . . . . . . . . . . . .   8
    4.  Delivery Reliability  . . . . . . . . . . . . . . . . . . . .   8
-   5.  Security Considerations . . . . . . . . . . . . . . . . . . .   8
-     5.1.  Authentication Using Signed SETs  . . . . . . . . . . . .   8
-     5.2.  TLS Support Considerations  . . . . . . . . . . . . . . .   8
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
+     5.1.  Authentication Using Signed SETs  . . . . . . . . . . . .   9
+     5.2.  TLS Support Considerations  . . . . . . . . . . . . . . .   9
      5.3.  Denial of Service . . . . . . . . . . . . . . . . . . . .   9
-     5.4.  Authenticating Persisted SETs . . . . . . . . . . . . . .   9
-   6.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .   9
+     5.4.  Authenticating Persisted SETs . . . . . . . . . . . . . .  10
+   6.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .  10
    7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
      7.1.  Security Event Token Delivery Error Codes . . . . . . . .  10
        7.1.1.  Registration Template . . . . . . . . . . . . . . . .  10
-       7.1.2.  Initial Registry Contents . . . . . . . . . . . . . .  10
-   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  11
-     8.1.  Normative References  . . . . . . . . . . . . . . . . . .  11
-     8.2.  Informative References  . . . . . . . . . . . . . . . . .  12
-   Appendix A.  Other Streaming Specifications . . . . . . . . . . .  12
-   Appendix B.  Acknowledgments  . . . . . . . . . . . . . . . . . .  14
-   Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  14
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  16
+       7.1.2.  Initial Registry Contents . . . . . . . . . . . . . .  11
+   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  12
+     8.1.  Normative References  . . . . . . . . . . . . . . . . . .  12
+     8.2.  Informative References  . . . . . . . . . . . . . . . . .  13
+   Appendix A.  Other Streaming Specifications . . . . . . . . . . .  13
+   Appendix B.  Acknowledgments  . . . . . . . . . . . . . . . . . .  15
+   Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  15
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  17
 
 1.  Introduction and Overview
 
@@ -212,9 +212,9 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
    the "Accept" header MUST be "application/json".  The request body
    MUST consist of the SET itself, represented as a JWT [RFC7519].
 
-   The mechanisms by which the SET Transmitter determines the HTTP
-   endpoint to use when transmitting a SET to a given SET Recipient are
-   not defined by this specification and may be implementation-specific.
+   The SET Transmitter MAY include in the request an "Accept-Language"
+   header to indicate to the SET Recipient the preferred language(s) in
+   which to receive error messages.
 
 
 
@@ -226,12 +226,17 @@ Backman, et al.           Expires June 9, 2019                  [Page 4]
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
+   The mechanisms by which the SET Transmitter determines the HTTP
+   endpoint to use when transmitting a SET to a given SET Recipient are
+   not defined by this specification and may be implementation-specific.
+
    The following is a non-normative example of a SET transmission
    request:
 
    POST /Events  HTTP/1.1
    Host: notify.rp.example.com
    Accept: application/json
+   Accept-Language: en-US, en;q=0.5
    Content-Type: application/secevent+jwt
 
    eyJhbGciOiJub25lIn0
@@ -269,11 +274,6 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
    SET Transmitter know that a SET has been delivered and the
    information no longer needs to be retained by the SET Transmitter.
    Before acknowledgement, SET Recipients SHOULD ensure they have
-   validated received SETs and retained them in a manner appropriate to
-   information retention requirements appropriate to the SET event types
-   signaled.  The level and method of retention of SETs by SET
-   Recipients is out of scope of this specification.
-
 
 
 
@@ -281,6 +281,11 @@ Backman, et al.           Expires June 9, 2019                  [Page 5]
 
 Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
+
+   validated received SETs and retained them in a manner appropriate to
+   information retention requirements appropriate to the SET event types
+   signaled.  The level and method of retention of SETs by SET
+   Recipients is out of scope of this specification.
 
 2.3.  Failure Response
 
@@ -292,40 +297,35 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
    transmitted in a SET Transmission Request, the SET Recipient SHALL
    respond with an HTTP Response Status Code of 400 (Bad Request).  The
    "Content-Type" header of this response MUST be "application/json",
-   and the body MUST be a JSON [RFC7159] object containing the following
-   name/value pairs:
+   and the body MUST be a UTF-8 encoded JSON [RFC7159] object containing
+   the following name/value pairs:
 
    err  A Security Event Token Error Code (see Section 2.4).
 
-   description  Human-readable text that describes the error and MAY
-      contain additional diagnostic information.  The exact content of
-      this field is implementation-specific.
+   description  A UTF-8 string containing a human-readable description
+      of the error that MAY provide additional diagnostic information.
+      The exact content of this field is implementation-specific.
 
-   The following is an example non-normative error response indicating
-   that the key used to encrypt the SET has been revoked.
+   The response MUST include a "Content-Language" header, whose value
+   indicates the language of the error descriptions included in the
+   response body.  If the SET Recipient can provide error descriptions
+   in multiple languages, they SHOULD choose the language to use
+   according to the value of the "Accept-Language" header sent by the
+   SET Transmitter in the transmission request, as described in
+   Section 5.3.5 of [RFC7231].  If the SET Transmitter did not send an
+   "Accept-Language" header, or if the SET Recipient does not support
+   any of the languages included in the header, the SET Recipient MUST
+   respond with messages that are understandable by an English-speaking
+   person, as described in Section 4.5 of [RFC2277].
 
-   HTTP/1.1 400 Bad Request
-   Content-Type: application/json
 
-   {
-     "err": "invalid_key",
-     "description": "Key ID 12345 has been revoked."
-   }
 
-              Figure 3: Example Error Response (invalid_key)
 
-   The following is an example non-normative error response indicating
-   that the access token included in the request is expired.
 
-   HTTP/1.1 400 Bad Request
-   Content-Type: application/json
 
-   {
-     "err": "authentication_failed",
-     "description": "Access token is expired."
-   }
 
-         Figure 4: Example Error Response (authentication_failed)
+
+
 
 
 
@@ -339,10 +339,39 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
    The following is an example non-normative error response indicating
+   that the key used to encrypt the SET has been revoked.
+
+   HTTP/1.1 400 Bad Request
+   Content-Language: en-US
+   Content-Type: application/json
+
+   {
+     "err": "invalid_key",
+     "description": "Key ID 12345 has been revoked."
+   }
+
+              Figure 3: Example Error Response (invalid_key)
+
+   The following is an example non-normative error response indicating
+   that the access token included in the request is expired.
+
+   HTTP/1.1 400 Bad Request
+   Content-Language: en-US
+   Content-Type: application/json
+
+   {
+     "err": "authentication_failed",
+     "description": "Access token is expired."
+   }
+
+         Figure 4: Example Error Response (authentication_failed)
+
+   The following is an example non-normative error response indicating
    that the SET Transmitter is not permitted to transmit SETs issued by
    the issuer specified in the SET.
 
    HTTP/1.1 400 Bad Request
+   Content-Language: en-US
    Content-Type: application/json
 
    {
@@ -357,6 +386,14 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
    Security Event Token Delivery Error Codes are strings that identify a
    specific category of error that may occur when parsing or validating
    a SET.  Every Security Event Token Delivery Error Code MUST have a
+
+
+
+Backman, et al.           Expires June 9, 2019                  [Page 7]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
+
    unique name registered in the IANA "Security Event Token Delivery
    Error Codes" registry established by Section 7.1.
 
@@ -386,14 +423,6 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
                      Table 1: SET Delivery Error Codes
 
-
-
-
-Backman, et al.           Expires June 9, 2019                  [Page 7]
-
-Internet-Draft        draft-ietf-secevent-http-push        December 2018
-
-
 3.  Authentication and Authorization
 
    The SET delivery method described in this specification is based upon
@@ -413,6 +442,14 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
    Recipient in such a way as to provide the SET Transmitter with the
    information necessary to determine what further action is required,
    if any, in order to meet their requirements.  SET Transmitters with
+
+
+
+Backman, et al.           Expires June 9, 2019                  [Page 8]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
+
    high reliability requirements may be tempted to always retry failed
    transmissions, however it should be noted that for many types of SET
    delivery errors, a retry is extremely unlikely to be successful.  For
@@ -442,14 +479,6 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
    SETs may contain sensitive information that is considered PII (e.g.,
    subject claims).  In such cases, SET Transmitters and SET Recipients
    MUST require the use of a transport-layer security mechanism.  Event
-
-
-
-Backman, et al.           Expires June 9, 2019                  [Page 8]
-
-Internet-Draft        draft-ietf-secevent-http-push        December 2018
-
-
    delivery endpoints MUST support TLS 1.2 [RFC5246] and MAY support
    additional transport-layer mechanisms meeting its security
    requirements.  When using TLS, the client MUST perform a TLS/SSL
@@ -465,6 +494,17 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
    cryptographic operations that are bound to fail.  This may be
    mitigated by authenticating SET Transmitters with a mechanism with
    low runtime overhead, such as mutual TLS.
+
+
+
+
+
+
+
+Backman, et al.           Expires June 9, 2019                  [Page 9]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
 
 5.4.  Authenticating Persisted SETs
 
@@ -495,17 +535,6 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
    example, the passing of a hash value that requires the subscriber to
    already know the subject.
 
-
-
-
-
-
-
-Backman, et al.           Expires June 9, 2019                  [Page 9]
-
-Internet-Draft        draft-ietf-secevent-http-push        December 2018
-
-
 7.  IANA Considerations
 
 7.1.  Security Event Token Delivery Error Codes
@@ -525,6 +554,13 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
       described in Section 2.4.  The name MUST be a case-sensitive ASCII
       string consisting only of upper-case letters ("A" - "Z"), lower-
       case letters ("a" - "z"), and digits ("0" - "9").
+
+
+
+Backman, et al.           Expires June 9, 2019                 [Page 10]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
 
    Description
       A brief human-readable description of the Security Event Token
@@ -554,14 +590,6 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
       Defining Document(s): Section 2.4 of this document
 
       Error Code: invalid_key
-
-
-
-Backman, et al.           Expires June 9, 2019                 [Page 10]
-
-Internet-Draft        draft-ietf-secevent-http-push        December 2018
-
-
       Description: One or more keys used to encrypt or sign the SET is
       invalid or otherwise unacceptable to the SET Recipient. (e.g.,
       expired, revoked, failed certificate validation, etc.)
@@ -580,6 +608,16 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
       Change Controller: IETF Secevent Working Group
       Defining Document(s): Section 2.4 of this document
 
+
+
+
+
+
+Backman, et al.           Expires June 9, 2019                 [Page 11]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
+
 8.  References
 
 8.1.  Normative References
@@ -588,6 +626,10 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
               editor.org/info/rfc2119>.
+
+   [RFC2277]  Alvestrand, H., "IETF Policy on Character Sets and
+              Languages", BCP 18, RFC 2277, DOI 10.17487/RFC2277,
+              January 1998, <https://www.rfc-editor.org/info/rfc2277>.
 
    [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
               (TLS) Protocol Version 1.2", RFC 5246,
@@ -610,14 +652,6 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
               DOI 10.17487/RFC7231, June 2014, <https://www.rfc-
               editor.org/info/rfc7231>.
 
-
-
-
-Backman, et al.           Expires June 9, 2019                 [Page 11]
-
-Internet-Draft        draft-ietf-secevent-http-push        December 2018
-
-
    [RFC7515]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web
               Signature (JWS)", RFC 7515, DOI 10.17487/RFC7515, May
               2015, <https://www.rfc-editor.org/info/rfc7515>.
@@ -629,6 +663,16 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
    [RFC7519]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web Token
               (JWT)", RFC 7519, DOI 10.17487/RFC7519, May 2015,
               <https://www.rfc-editor.org/info/rfc7519>.
+
+
+
+
+
+
+Backman, et al.           Expires June 9, 2019                 [Page 12]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
 
    [RFC7525]  Sheffer, Y., Holz, R., and P. Saint-Andre,
               "Recommendations for Secure Use of Transport Layer
@@ -666,14 +710,6 @@ Appendix A.  Other Streaming Specifications
 
    XMPP Events
 
-
-
-
-Backman, et al.           Expires June 9, 2019                 [Page 12]
-
-Internet-Draft        draft-ietf-secevent-http-push        December 2018
-
-
    The WG considered the XMPP events ands its ability to provide a
    single messaging solution without the need for both polling and push
    modes.  The feeling was the size and methodology of XMPP was to far
@@ -686,6 +722,14 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
    SNS supports a variety of subscriber types: HTTP/HTTPS endpoints, AWS
    Lambda functions, email addresses (as JSON or plain text), phone
    numbers (via SMS), and AWS SQS standard queues.  It doesn't directly
+
+
+
+Backman, et al.           Expires June 9, 2019                 [Page 13]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
+
    support pull, but subscribers can get the pull model by creating an
    SQS queue and subscribing it to the topic.  Note that this puts the
    cost of pull support back onto the subscriber, just as it is in the
@@ -720,16 +764,6 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
    Google Pub/Sub
 
-
-
-
-
-
-Backman, et al.           Expires June 9, 2019                 [Page 13]
-
-Internet-Draft        draft-ietf-secevent-http-push        December 2018
-
-
    Google Pub Sub system favours a model whereby polling and
    acknowledgement of events is done as separate endpoints as separate
    functions.
@@ -742,6 +776,15 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
       subscriber
 
    o  Subscriber Pull(poll) - https://cloud.google.com/pubsub/docs/pull
+
+
+
+
+
+Backman, et al.           Expires June 9, 2019                 [Page 14]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
 
 Appendix B.  Acknowledgments
 
@@ -779,13 +822,6 @@ Appendix C.  Change Log
 
    o  Removed enumeration of HTTP authentication methods.
 
-
-
-Backman, et al.           Expires June 9, 2019                 [Page 14]
-
-Internet-Draft        draft-ietf-secevent-http-push        December 2018
-
-
    o  Removed generally applicable guidance for HTTP, authorization
       tokens, and bearer tokens.
 
@@ -796,6 +832,15 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
    o  Removed further generally applicable guidance for authorization
       tokens.
+
+
+
+
+
+Backman, et al.           Expires June 9, 2019                 [Page 15]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
 
    o  Removed bearer token from example delivery request, and text
       referencing it.
@@ -834,14 +879,6 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
    o  Removed Event Delivery Process section and moved its content to
       parent section.
 
-
-
-
-Backman, et al.           Expires June 9, 2019                 [Page 15]
-
-Internet-Draft        draft-ietf-secevent-http-push        December 2018
-
-
    o  Readability edits to SET Delivery section and its subsections.
 
    o  Added callout that SET Receiver HTTP endpoint configuration is
@@ -851,6 +888,15 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
    o  Added retry guidance, notes regarding delivery reliability
       requirements.
+
+
+
+
+
+Backman, et al.           Expires June 9, 2019                 [Page 16]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
 
    o  Added guidance around using JWS and/or JWE to authenticate
       persisted SETs.
@@ -881,6 +927,12 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
    o  Added text clarifying that the value of the "description"
       attribute in error responses is implementation specific.
 
+   o  Added requirement that error descriptions and responses are UTF-8
+      encoded.
+
+   o  Added error description language preferences and specification via
+      "Accept-Language" and "Content-Language" headers.
+
 Authors' Addresses
 
    Annabelle Backman (editor)
@@ -889,20 +941,17 @@ Authors' Addresses
    Email: richanna@amazon.com
 
 
-
-
-
-
-Backman, et al.           Expires June 9, 2019                 [Page 16]
-
-Internet-Draft        draft-ietf-secevent-http-push        December 2018
-
-
    Michael B. Jones (editor)
    Microsoft
 
    Email: mbj@microsoft.com
    URI:   http://self-issued.info/
+
+
+
+Backman, et al.           Expires June 9, 2019                 [Page 17]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
    Marius Scurtescu
@@ -949,4 +998,11 @@ Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 
-Backman, et al.           Expires June 9, 2019                 [Page 17]
+
+
+
+
+
+
+
+Backman, et al.           Expires June 9, 2019                 [Page 18]

--- a/draft-ietf-secevent-http-push.txt
+++ b/draft-ietf-secevent-http-push.txt
@@ -5,14 +5,14 @@
 Security Events Working Group                            A. Backman, Ed.
 Internet-Draft                                                    Amazon
 Intended status: Standards Track                           M. Jones, Ed.
-Expires: April 21, 2019                                        Microsoft
+Expires: June 9, 2019                                          Microsoft
                                                             M. Scurtescu
                                                                 Coinbase
                                                                M. Ansari
                                                                    Cisco
                                                               A. Nadalin
                                                                Microsoft
-                                                        October 18, 2018
+                                                        December 6, 2018
 
 
        Push-Based Security Event Token (SET) Delivery Using HTTP
@@ -34,14 +34,14 @@ Status of This Memo
    Internet-Drafts are working documents of the Internet Engineering
    Task Force (IETF).  Note that other groups may also distribute
    working documents as Internet-Drafts.  The list of current Internet-
-   Drafts is at https://datatracker.ietf.org/drafts/current/.
+   Drafts is at http://datatracker.ietf.org/drafts/current/.
 
    Internet-Drafts are draft documents valid for a maximum of six months
    and may be updated, replaced, or obsoleted by other documents at any
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on April 21, 2019.
+   This Internet-Draft will expire on June 9, 2019.
 
 Copyright Notice
 
@@ -53,12 +53,12 @@ Copyright Notice
 
 
 
-Backman, et al.          Expires April 21, 2019                 [Page 1]
+Backman, et al.           Expires June 9, 2019                  [Page 1]
 
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
-   (https://trustee.ietf.org/license-info) in effect on the date of
+   (http://trustee.ietf.org/license-info) in effect on the date of
    publication of this document.  Please review these documents
    carefully, as they describe your rights and restrictions with respect
    to this document.  Code Components extracted from this document must
@@ -75,26 +75,26 @@ Table of Contents
      2.1.  Transmitting a SET  . . . . . . . . . . . . . . . . . . .   4
      2.2.  Success Response  . . . . . . . . . . . . . . . . . . . .   5
      2.3.  Failure Response  . . . . . . . . . . . . . . . . . . . .   6
-     2.4.  Security Event Token Delivery Error Codes . . . . . . . .   6
-   3.  Authentication and Authorization  . . . . . . . . . . . . . .   7
-   4.  Delivery Reliability  . . . . . . . . . . . . . . . . . . . .   7
+     2.4.  Security Event Token Delivery Error Codes . . . . . . . .   7
+   3.  Authentication and Authorization  . . . . . . . . . . . . . .   8
+   4.  Delivery Reliability  . . . . . . . . . . . . . . . . . . . .   8
    5.  Security Considerations . . . . . . . . . . . . . . . . . . .   8
      5.1.  Authentication Using Signed SETs  . . . . . . . . . . . .   8
      5.2.  TLS Support Considerations  . . . . . . . . . . . . . . .   8
-     5.3.  Denial of Service . . . . . . . . . . . . . . . . . . . .   8
-     5.4.  Authenticating Persisted SETs . . . . . . . . . . . . . .   8
+     5.3.  Denial of Service . . . . . . . . . . . . . . . . . . . .   9
+     5.4.  Authenticating Persisted SETs . . . . . . . . . . . . . .   9
    6.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .   9
-   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   9
-     7.1.  Security Event Token Delivery Error Codes . . . . . . . .   9
-       7.1.1.  Registration Template . . . . . . . . . . . . . . . .   9
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
+     7.1.  Security Event Token Delivery Error Codes . . . . . . . .  10
+       7.1.1.  Registration Template . . . . . . . . . . . . . . . .  10
        7.1.2.  Initial Registry Contents . . . . . . . . . . . . . .  10
    8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  11
      8.1.  Normative References  . . . . . . . . . . . . . . . . . .  11
-     8.2.  Informative References  . . . . . . . . . . . . . . . . .  13
-   Appendix A.  Other Streaming Specifications . . . . . . . . . . .  13
-   Appendix B.  Acknowledgments  . . . . . . . . . . . . . . . . . .  15
-   Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  15
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  17
+     8.2.  Informative References  . . . . . . . . . . . . . . . . .  12
+   Appendix A.  Other Streaming Specifications . . . . . . . . . . .  12
+   Appendix B.  Acknowledgments  . . . . . . . . . . . . . . . . . .  14
+   Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  14
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  16
 
 1.  Introduction and Overview
 
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Backman, et al.          Expires April 21, 2019                 [Page 2]
+Backman, et al.           Expires June 9, 2019                  [Page 2]
 
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
    o  The transmitter of the SET is capable of making outbound HTTP
@@ -165,9 +165,9 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
 
 
 
-Backman, et al.          Expires April 21, 2019                 [Page 3]
+Backman, et al.           Expires June 9, 2019                  [Page 3]
 
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
    o  The SET Recipient is identified as an intended audience of the
@@ -221,9 +221,9 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
 
 
 
-Backman, et al.          Expires April 21, 2019                 [Page 4]
+Backman, et al.           Expires June 9, 2019                  [Page 4]
 
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
    The following is a non-normative example of a SET transmission
@@ -277,9 +277,9 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
 
 
 
-Backman, et al.          Expires April 21, 2019                 [Page 5]
+Backman, et al.           Expires June 9, 2019                  [Page 5]
 
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
 2.3.  Failure Response
@@ -292,32 +292,71 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
    transmitted in a SET Transmission Request, the SET Recipient SHALL
    respond with an HTTP Response Status Code of 400 (Bad Request).  The
    "Content-Type" header of this response MUST be "application/json",
-   and the body MUST be a JSON object containing the following name/
-   value pairs:
+   and the body MUST be a JSON [RFC7159] object containing the following
+   name/value pairs:
 
    err  A Security Event Token Error Code (see Section 2.4).
 
    description  Human-readable text that describes the error and MAY
-      contain additional diagnostic information.
+      contain additional diagnostic information.  The exact content of
+      this field is implementation-specific.
 
-   The following is an example non-normative error response.
+   The following is an example non-normative error response indicating
+   that the key used to encrypt the SET has been revoked.
 
    HTTP/1.1 400 Bad Request
    Content-Type: application/json
 
    {
-   "err":"dup",
-   "description":"SET already received. Ignored."
-
+     "err": "invalid_key",
+     "description": "Key ID 12345 has been revoked."
    }
 
-                     Figure 3: Example Error Response
+              Figure 3: Example Error Response (invalid_key)
+
+   The following is an example non-normative error response indicating
+   that the access token included in the request is expired.
+
+   HTTP/1.1 400 Bad Request
+   Content-Type: application/json
+
+   {
+     "err": "authentication_failed",
+     "description": "Access token is expired."
+   }
+
+         Figure 4: Example Error Response (authentication_failed)
+
+
+
+
+
+
+
+Backman, et al.           Expires June 9, 2019                  [Page 6]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
+
+   The following is an example non-normative error response indicating
+   that the SET Transmitter is not permitted to transmit SETs issued by
+   the issuer specified in the SET.
+
+   HTTP/1.1 400 Bad Request
+   Content-Type: application/json
+
+   {
+     "err": "access_denied",
+     "description": "Not authorized for issuer http://iss.example.com/."
+   }
+
+             Figure 5: Example Error Response (access_denied)
 
 2.4.  Security Event Token Delivery Error Codes
 
    Security Event Token Delivery Error Codes are strings that identify a
-   specific type of error that may occur when parsing or validating a
-   SET.  Every Security Event Token Delivery Error Code MUST have a
+   specific category of error that may occur when parsing or validating
+   a SET.  Every Security Event Token Delivery Error Code MUST have a
    unique name registered in the IANA "Security Event Token Delivery
    Error Codes" registry established by Section 7.1.
 
@@ -325,40 +364,35 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
    registered in the IANA "Security Event Token Delivery Error Codes"
    registry:
 
-
-
-
-
-
-
-
-
-Backman, et al.          Expires April 21, 2019                 [Page 6]
-
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
-
-
-   +-----------+-------------------------------------------------------+
-   | Error     | Description                                           |
-   | Code      |                                                       |
-   +-----------+-------------------------------------------------------+
-   | json      | Invalid JSON object.                                  |
-   | jwtParse  | Invalid or unparsable JWT or JSON structure.          |
-   | jwtHdr    | An invalid JWT header was detected.                   |
-   | jwtCrypto | Unable to parse due to unsupported algorithm.         |
-   | jws       | Signature was not validated.                          |
-   | jwe       | Unable to decrypt JWE encoded data.                   |
-   | jwtAud    | Invalid audience value.                               |
-   | jwtIss    | Issuer not recognized.                                |
-   | setType   | An unexpected Event type was received.                |
-   | setParse  | Invalid structure was encountered such as an          |
-   |           | inability to parse or an incomplete set of Event      |
-   |           | claims.                                               |
-   | setData   | SET claims incomplete or invalid.                     |
-   | dup       | A duplicate SET was received and has been ignored.    |
-   +-----------+-------------------------------------------------------+
+   +-----------------------+-------------------------------------------+
+   | Error Code            | Description                               |
+   +-----------------------+-------------------------------------------+
+   | invalid_request       | The request body cannot be parsed as a    |
+   |                       | SET, or the event payload within the SET  |
+   |                       | does not conform to the event's           |
+   |                       | definition.                               |
+   | invalid_key           | One or more keys used to encrypt or sign  |
+   |                       | the SET is invalid or otherwise           |
+   |                       | unacceptable to the SET Recipient. (e.g., |
+   |                       | expired, revoked, failed certificate      |
+   |                       | validation, etc.)                         |
+   | authentication_failed | The SET Recipient could not authenticate  |
+   |                       | the SET Transmitter from the contents of  |
+   |                       | the request.                              |
+   | access_denied         | The SET Transmitter is not authorized to  |
+   |                       | transmit the provided SET to the SET      |
+   |                       | Recipient.                                |
+   +-----------------------+-------------------------------------------+
 
                      Table 1: SET Delivery Error Codes
+
+
+
+
+Backman, et al.           Expires June 9, 2019                  [Page 7]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
 
 3.  Authentication and Authorization
 
@@ -382,20 +416,11 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
    high reliability requirements may be tempted to always retry failed
    transmissions, however it should be noted that for many types of SET
    delivery errors, a retry is extremely unlikely to be successful.  For
-   example, "json", "jwtParse", and "setParse" all indicate structural
-   errors in the content of the SET that are likely to remain when re-
-   transmitting the same SET.  Others such as "jws" or "jwe" may be
-
-
-
-
-Backman, et al.          Expires April 21, 2019                 [Page 7]
-
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
-
-
-   transient, for example if cryptographic material has not been
-   properly distributed to the SET Recipient's systems.
+   example, "invalid_request" indicates a structural error in the
+   content of the request body that is likely to remain when re-
+   transmitting the same SET.  Others such as "access_denied" may be
+   transient, for example if the SET Transmitter refreshes expired
+   credentials prior to re-transmission.
 
    Implementers SHOULD evaluate their reliability requirements and the
    impact of various retry mechanisms on the performance of their
@@ -417,6 +442,14 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
    SETs may contain sensitive information that is considered PII (e.g.,
    subject claims).  In such cases, SET Transmitters and SET Recipients
    MUST require the use of a transport-layer security mechanism.  Event
+
+
+
+Backman, et al.           Expires June 9, 2019                  [Page 8]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
+
    delivery endpoints MUST support TLS 1.2 [RFC5246] and MAY support
    additional transport-layer mechanisms meeting its security
    requirements.  When using TLS, the client MUST perform a TLS/SSL
@@ -442,14 +475,6 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
    typically unavailable to systems that the SET Recipient forwards the
    SET onto, or to systems that retrieve the SET from storage.  If the
    SET Recipient requires the ability to validate SET authenticity
-
-
-
-Backman, et al.          Expires April 21, 2019                 [Page 8]
-
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
-
-
    outside of the context of the transmission request, then the SET
    Transmitter SHOULD sign the SET in accordance with [RFC7515] and
    optionally also encrypt it in accordance with [RFC7516].
@@ -469,6 +494,17 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
    Recipients SHOULD devise approaches that prevent propagation -- for
    example, the passing of a hash value that requires the subscriber to
    already know the subject.
+
+
+
+
+
+
+
+Backman, et al.           Expires June 9, 2019                  [Page 9]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
 
 7.  IANA Considerations
 
@@ -498,14 +534,6 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
       For error codes registered by the IETF or its working groups, list
       "IETF Secevent Working Group".  For all other error codes, list
       the name of the party responsible for the registration.  Contact
-
-
-
-Backman, et al.          Expires April 21, 2019                 [Page 9]
-
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
-
-
       information such as mailing address, email address, or phone
       number may also be provided.
 
@@ -518,72 +546,37 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
 
 7.1.2.  Initial Registry Contents
 
-      Error Code: json
-      Description: Invalid JSON object
+      Error Code: invalid_request
+      Description: The request body cannot be parsed as a SET, or the
+      event payload within the SET does not conform to the event's
+      definition.
       Change Controller: IETF Secevent Working Group
       Defining Document(s): Section 2.4 of this document
 
-      Error Code: jwtParse
-      Description: Invalid or unparsable JWT or JSON structure
-      Change Controller: IETF Secevent Working Group
-      Defining Document(s): Section 2.4 of this document
-
-      Error Code: jwtHdr
-      Description: An invalid JWT header was detected
-      Change Controller: IETF Secevent Working Group
-      Defining Document(s): Section 2.4 of this document
-
-      Error Code: jwtCrypto
-      Description: Unable to parse due to unsupported algorithm
-      Change Controller: IETF Secevent Working Group
-      Defining Document(s): Section 2.4 of this document
-
-      Error Code: jws
-      Description: Signature was not validated
-      Change Controller: IETF Secevent Working Group
-      Defining Document(s): Section 2.4 of this document
-
-      Error Code: jwe
-      Description: Unable to decrypt JWE encoded data
-      Change Controller: IETF Secevent Working Group
-      Defining Document(s): Section 2.4 of this document
-
-      Error Code: jwtAud
-      Description: Invalid audience value
-      Change Controller: IETF Secevent Working Group
-      Defining Document(s): Section 2.4 of this document
-
-      Error Code: jwtIss
+      Error Code: invalid_key
 
 
 
-Backman, et al.          Expires April 21, 2019                [Page 10]
+Backman, et al.           Expires June 9, 2019                 [Page 10]
 
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
-      Description: Issuer not recognized
-      Change Controller:
-      Defining Document(s): Section 2.4 of this document
-
-      Error Code: setType
-      Description: An unexpected Event type was received
+      Description: One or more keys used to encrypt or sign the SET is
+      invalid or otherwise unacceptable to the SET Recipient. (e.g.,
+      expired, revoked, failed certificate validation, etc.)
       Change Controller: IETF Secevent Working Group
       Defining Document(s): Section 2.4 of this document
 
-      Error Code: setParse
-      Description: Invalid structure was encountered such as an
-      inability to parse or an incomplete set of Event claims.
+      Error Code: authentication_failed
+      Description: The SET Recipient could not authenticate the SET
+      Transmitter from the contents of the request.
       Change Controller: IETF Secevent Working Group
       Defining Document(s): Section 2.4 of this document
 
-      Error Code: setData
-      Description: SET claims incomplete or invalid
-      Change Controller: IETF Secevent Working Group
-      Defining Document(s): Section 2.4 of this document
-
-      Error Code: dup
-      Description: A duplicate SET was received and has been ignored.
+      Error Code: access_denied
+      Description: The SET Transmitter is not authorized to transmit the
+      provided SET to the SET Recipient.
       Change Controller: IETF Secevent Working Group
       Defining Document(s): Section 2.4 of this document
 
@@ -593,30 +586,13 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
-              DOI 10.17487/RFC2119, March 1997,
-              <https://www.rfc-editor.org/info/rfc2119>.
-
-   [RFC3986]  Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform
-              Resource Identifier (URI): Generic Syntax", STD 66,
-              RFC 3986, DOI 10.17487/RFC3986, January 2005,
-              <https://www.rfc-editor.org/info/rfc3986>.
+              DOI 10.17487/RFC2119, March 1997, <https://www.rfc-
+              editor.org/info/rfc2119>.
 
    [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
               (TLS) Protocol Version 1.2", RFC 5246,
-              DOI 10.17487/RFC5246, August 2008,
-              <https://www.rfc-editor.org/info/rfc5246>.
-
-   [RFC5988]  Nottingham, M., "Web Linking", RFC 5988,
-              DOI 10.17487/RFC5988, October 2010,
-              <https://www.rfc-editor.org/info/rfc5988>.
-
-
-
-
-Backman, et al.          Expires April 21, 2019                [Page 11]
-
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
-
+              DOI 10.17487/RFC5246, August 2008, <https://www.rfc-
+              editor.org/info/rfc5246>.
 
    [RFC6125]  Saint-Andre, P. and J. Hodges, "Representation and
               Verification of Domain-Based Application Service Identity
@@ -631,8 +607,16 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
 
    [RFC7231]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
               Protocol (HTTP/1.1): Semantics and Content", RFC 7231,
-              DOI 10.17487/RFC7231, June 2014,
-              <https://www.rfc-editor.org/info/rfc7231>.
+              DOI 10.17487/RFC7231, June 2014, <https://www.rfc-
+              editor.org/info/rfc7231>.
+
+
+
+
+Backman, et al.           Expires June 9, 2019                 [Page 11]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
+
 
    [RFC7515]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web
               Signature (JWS)", RFC 7515, DOI 10.17487/RFC7515, May
@@ -641,10 +625,6 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
    [RFC7516]  Jones, M. and J. Hildebrand, "JSON Web Encryption (JWE)",
               RFC 7516, DOI 10.17487/RFC7516, May 2015,
               <https://www.rfc-editor.org/info/rfc7516>.
-
-   [RFC7517]  Jones, M., "JSON Web Key (JWK)", RFC 7517,
-              DOI 10.17487/RFC7517, May 2015,
-              <https://www.rfc-editor.org/info/rfc7517>.
 
    [RFC7519]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web Token
               (JWT)", RFC 7519, DOI 10.17487/RFC7519, May 2015,
@@ -665,53 +645,17 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
-
-
-
-
-Backman, et al.          Expires April 21, 2019                [Page 12]
-
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
-
-
    [RFC8417]  Hunt, P., Ed., Jones, M., Denniss, W., and M. Ansari,
               "Security Event Token (SET)", RFC 8417,
-              DOI 10.17487/RFC8417, July 2018,
-              <https://www.rfc-editor.org/info/rfc8417>.
+              DOI 10.17487/RFC8417, July 2018, <https://www.rfc-
+              editor.org/info/rfc8417>.
 
 8.2.  Informative References
 
-   [RFC3339]  Klyne, G. and C. Newman, "Date and Time on the Internet:
-              Timestamps", RFC 3339, DOI 10.17487/RFC3339, July 2002,
-              <https://www.rfc-editor.org/info/rfc3339>.
-
-   [RFC6749]  Hardt, D., Ed., "The OAuth 2.0 Authorization Framework",
-              RFC 6749, DOI 10.17487/RFC6749, October 2012,
-              <https://www.rfc-editor.org/info/rfc6749>.
-
-   [RFC6750]  Jones, M. and D. Hardt, "The OAuth 2.0 Authorization
-              Framework: Bearer Token Usage", RFC 6750,
-              DOI 10.17487/RFC6750, October 2012,
-              <https://www.rfc-editor.org/info/rfc6750>.
-
-   [RFC7230]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
-              Protocol (HTTP/1.1): Message Syntax and Routing",
-              RFC 7230, DOI 10.17487/RFC7230, June 2014,
-              <https://www.rfc-editor.org/info/rfc7230>.
-
    [RFC7235]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
               Protocol (HTTP/1.1): Authentication", RFC 7235,
-              DOI 10.17487/RFC7235, June 2014,
-              <https://www.rfc-editor.org/info/rfc7235>.
-
-   [RFC7521]  Campbell, B., Mortimore, C., Jones, M., and Y. Goland,
-              "Assertion Framework for OAuth 2.0 Client Authentication
-              and Authorization Grants", RFC 7521, DOI 10.17487/RFC7521,
-              May 2015, <https://www.rfc-editor.org/info/rfc7521>.
-
-   [RFC7617]  Reschke, J., "The 'Basic' HTTP Authentication Scheme",
-              RFC 7617, DOI 10.17487/RFC7617, September 2015,
-              <https://www.rfc-editor.org/info/rfc7617>.
+              DOI 10.17487/RFC7235, June 2014, <https://www.rfc-
+              editor.org/info/rfc7235>.
 
 Appendix A.  Other Streaming Specifications
 
@@ -725,9 +669,9 @@ Appendix A.  Other Streaming Specifications
 
 
 
-Backman, et al.          Expires April 21, 2019                [Page 13]
+Backman, et al.           Expires June 9, 2019                 [Page 12]
 
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
    The WG considered the XMPP events ands its ability to provide a
@@ -781,9 +725,9 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
 
 
 
-Backman, et al.          Expires April 21, 2019                [Page 14]
+Backman, et al.           Expires June 9, 2019                 [Page 13]
 
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
    Google Pub Sub system favours a model whereby polling and
@@ -837,9 +781,9 @@ Appendix C.  Change Log
 
 
 
-Backman, et al.          Expires April 21, 2019                [Page 15]
+Backman, et al.           Expires June 9, 2019                 [Page 14]
 
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
    o  Removed generally applicable guidance for HTTP, authorization
@@ -893,9 +837,9 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
 
 
 
-Backman, et al.          Expires April 21, 2019                [Page 16]
+Backman, et al.           Expires June 9, 2019                 [Page 15]
 
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
    o  Readability edits to SET Delivery section and its subsections.
@@ -923,12 +867,35 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
 
    o  Updated Marius' contact information.
 
+   Draft 04 - AB:
+
+   o  Replaced Error Codes with smaller set of meaningfully
+      differentiated codes.
+
+   o  Added more error response examples.
+
+   o  Removed un-referenced normative references.
+
+   o  Added normative reference to JSON in error response definition.
+
+   o  Added text clarifying that the value of the "description"
+      attribute in error responses is implementation specific.
+
 Authors' Addresses
 
    Annabelle Backman (editor)
    Amazon
 
    Email: richanna@amazon.com
+
+
+
+
+
+
+Backman, et al.           Expires June 9, 2019                 [Page 16]
+
+Internet-Draft        draft-ietf-secevent-http-push        December 2018
 
 
    Michael B. Jones (editor)
@@ -942,16 +909,6 @@ Authors' Addresses
    Coinbase
 
    Email: marius.scurtescu@coinbase.com
-
-
-
-
-
-
-
-Backman, et al.          Expires April 21, 2019                [Page 17]
-
-Internet-Draft        draft-ietf-secevent-http-push         October 2018
 
 
    Morteza Ansari
@@ -992,17 +949,4 @@ Internet-Draft        draft-ietf-secevent-http-push         October 2018
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-Backman, et al.          Expires April 21, 2019                [Page 18]
+Backman, et al.           Expires June 9, 2019                 [Page 17]

--- a/draft-ietf-secevent-http-push.xml
+++ b/draft-ietf-secevent-http-push.xml
@@ -255,7 +255,7 @@ tZSI6Impkb2UiLCJpZCI6IjQ0ZjYxNDJkZjk2YmQ2YWI2MWU3NTIxZDkiLCJuYW
                     validating a SET transmitted in a SET Transmission Request,
                     the SET Recipient SHALL respond with an HTTP Response Status Code
                     of 400 (Bad Request).  The <spanx style="verb">Content-Type</spanx> header of this
-                    response MUST be "application/json", and the body MUST be a JSON
+                    response MUST be "application/json", and the body MUST be a <xref target="RFC7159">JSON</xref>
                     object containing the following name/value pairs:
                     <list style="hanging">
                         <t hangText="err">
@@ -263,28 +263,53 @@ tZSI6Impkb2UiLCJpZCI6IjQ0ZjYxNDJkZjk2YmQ2YWI2MWU3NTIxZDkiLCJuYW
                         </t>
                         <t hangText="description">
                             Human-readable text that describes the error and MAY contain
-                            additional diagnostic information.
+                            additional diagnostic information. The exact content of this
+                            field is implementation-specific.
                         </t>
                     </list>
                 </t>
 
-                <figure anchor="badPostResponse" title="Example Error Response">
-                    <preamble>The following is an example non-normative error
-                        response.</preamble>
+                <figure anchor="errorResponseInvalidKey" title="Example Error Response (invalid_key)">
+                    <preamble>The following is an example non-normative error response indicating
+                        that the key used to encrypt the SET has been revoked.</preamble>
                     <artwork>HTTP/1.1 400 Bad Request
 Content-Type: application/json
 
 {
-"err":"dup",
-"description":"SET already received. Ignored."
+  "err": "invalid_key",
+  "description": "Key ID 12345 has been revoked."
+}</artwork>
+                </figure>
 
+                <figure anchor="errorResponseExpiredToken" title="Example Error Response (authentication_failed)">
+                    <preamble>The following is an example non-normative error response indicating
+                        that the access token included in the request is expired.</preamble>
+                    <artwork>HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "err": "authentication_failed",
+  "description": "Access token is expired."
+}</artwork>
+                </figure>
+
+                <figure anchor="errorResponseBadIssuer" title="Example Error Response (access_denied)">
+                    <preamble>The following is an example non-normative error response indicating
+                        that the SET Transmitter is not permitted to transmit SETs issued by the
+                        issuer specified in the SET.</preamble>
+                    <artwork>HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+  "err": "access_denied",
+  "description": "Not authorized for issuer http://iss.example.com/."
 }</artwork>
                 </figure>
             </section>
 
             <section anchor="error_codes" title="Security Event Token Delivery Error Codes">
                 <t>Security Event Token Delivery Error Codes are strings that identify a
-                    specific type of error that may occur when parsing or validating a SET.
+                    specific category of error that may occur when parsing or validating a SET.
                     Every Security Event Token Delivery Error Code MUST have a unique name
                     registered in the IANA "Security Event Token Delivery Error Codes"
                     registry established by <xref target="iana_set_errors"/>.</t>
@@ -293,19 +318,15 @@ Content-Type: application/json
                     in the IANA "Security Event Token Delivery Error Codes" registry:</t>
                 <texttable anchor="reqErrors" title="SET Delivery Error Codes">
                     <ttcol>Error Code</ttcol><ttcol>Description</ttcol>
-                    <c>json</c><c>Invalid JSON object.</c>
-                    <c>jwtParse</c><c>Invalid or unparsable JWT or JSON structure.</c>
-                    <c>jwtHdr</c><c>An invalid JWT header was detected.</c>
-                    <c>jwtCrypto</c><c>Unable to parse due to unsupported algorithm.</c>
-                    <c>jws</c><c>Signature was not validated.</c>
-                    <c>jwe</c><c>Unable to decrypt JWE encoded data.</c>
-                    <c>jwtAud</c><c>Invalid audience value.</c>
-                    <c>jwtIss</c><c>Issuer not recognized.</c>
-                    <c>setType</c><c>An unexpected Event type was received.</c>
-                    <c>setParse</c><c>Invalid structure was encountered such as an
-                        inability to parse or an incomplete set of Event claims.</c>
-                    <c>setData</c><c>SET claims incomplete or invalid.</c>
-                    <c>dup</c><c>A duplicate SET was received and has been ignored.</c>
+                    <c>invalid_request</c><c>The request body cannot be parsed as a SET, or the
+                        event payload within the SET does not conform to the event's definition.</c>
+                    <c>invalid_key</c><c>One or more keys used to encrypt or sign the SET is
+                        invalid or otherwise unacceptable to the SET Recipient. (e.g., expired,
+                        revoked, failed certificate validation, etc.)</c>
+                    <c>authentication_failed</c><c>The SET Recipient could not authenticate the
+                        SET Transmitter from the contents of the request.</c>
+                    <c>access_denied</c><c>The SET Transmitter is not authorized to transmit the
+                        provided SET to the SET Recipient.</c>
                 </texttable>
             </section>
         </section>
@@ -334,13 +355,11 @@ Content-Type: application/json
                 high reliability requirements may be tempted to always retry failed
                 transmissions, however it should be noted that for many types of SET
                 delivery errors, a retry is extremely unlikely to be successful.  For
-                example, <spanx style="verb">json</spanx>, <spanx style="verb">jwtParse</spanx>,
-                and <spanx style="verb">setParse</spanx> all indicate structural errors
-                in the content of the SET that are likely to remain when re-transmitting
-                the same SET.  Others such as <spanx style="verb">jws</spanx> or
-                <spanx style="verb">jwe</spanx> may be transient, for example if
-                cryptographic material has not been properly distributed to the SET
-                Recipient's systems.
+                example, <spanx style="verb">invalid_request</spanx> indicates a structural
+                error in the content of the request body that is likely to remain when
+                re-transmitting the same SET.  Others such as <spanx style="verb">access_denied</spanx>
+                may be transient, for example if the SET Transmitter refreshes expired
+                credentials prior to re-transmission.
             </t>
             <t>
                 Implementers SHOULD evaluate their reliability requirements and the
@@ -464,8 +483,9 @@ Content-Type: application/json
 		  <t>
 		    <?rfc subcompact="yes"?>
 		    <list style="hanging">
-		      <t>Error Code: json</t>
-		      <t>Description: Invalid JSON object</t>
+		      <t>Error Code: invalid_request</t>
+                      <t>Description: The request body cannot be parsed as a SET, or the event
+                          payload within the SET does not conform to the event's definition.</t>
 		      <t>Change Controller: IETF Secevent Working Group</t>
 		      <t>Defining Document(s): 
 		      <xref target="error_codes"/> of this document
@@ -474,8 +494,10 @@ Content-Type: application/json
 		  </t>
 		  <t>
 		    <list style="hanging">
-		      <t>Error Code: jwtParse</t>
-		      <t>Description: Invalid or unparsable JWT or JSON structure</t>
+                      <t>Error Code: invalid_key</t>
+                      <t>Description: One or more keys used to encrypt or sign the SET is invalid
+                          or otherwise unacceptable to the SET Recipient. (e.g., expired, revoked,
+                          failed certificate validation, etc.)</t>
 		      <t>Change Controller: IETF Secevent Working Group</t>
 		      <t>Defining Document(s): 
 		      <xref target="error_codes"/> of this document
@@ -484,8 +506,9 @@ Content-Type: application/json
 		  </t>
 		  <t>
 		    <list style="hanging">
-		      <t>Error Code: jwtHdr</t>
-		      <t>Description: An invalid JWT header was detected</t>
+                      <t>Error Code: authentication_failed</t>
+                      <t>Description: The SET Recipient could not authenticate the SET Transmitter
+                          from the contents of the request.</t>
 		      <t>Change Controller: IETF Secevent Working Group</t>
 		      <t>Defining Document(s): 
 		      <xref target="error_codes"/> of this document
@@ -494,92 +517,9 @@ Content-Type: application/json
 		  </t>
 		  <t>
 		    <list style="hanging">
-		      <t>Error Code: jwtCrypto</t>
-		      <t>Description: Unable to parse due to unsupported algorithm</t>
-		      <t>Change Controller: IETF Secevent Working Group</t>
-		      <t>Defining Document(s): 
-		      <xref target="error_codes"/> of this document
-		      </t>
-		    </list>
-		  </t>
-		  <t>
-		    <list style="hanging">
-		      <t>Error Code: jws</t>
-		      <t>Description: Signature was not validated</t>
-		      <t>Change Controller: IETF Secevent Working Group</t>
-		      <t>Defining Document(s): 
-		      <xref target="error_codes"/> of this document
-		      </t>
-		    </list>
-		  </t>
-		  <t>
-		    <list style="hanging">
-		      <t>Error Code: jwe</t>
-		      <t>Description: Unable to decrypt JWE encoded data</t>
-		      <t>Change Controller: IETF Secevent Working Group</t>
-		      <t>Defining Document(s): 
-		      <xref target="error_codes"/> of this document
-		      </t>
-		    </list>
-		  </t>
-		  <t>
-		    <list style="hanging">
-		      <t>Error Code: jwtAud</t>
-		      <t>Description: Invalid audience value</t>
-		      <t>Change Controller: IETF Secevent Working Group</t>
-		      <t>Defining Document(s): 
-		      <xref target="error_codes"/> of this document
-		      </t>
-		    </list>
-		  </t>
-		  <t>
-		    <list style="hanging">
-		      <t>Error Code: jwtIss</t>
-		      <t>Description: Issuer not recognized</t>
-		      <t>Change Controller: </t>
-		      <t>Defining Document(s): 
-		      <xref target="error_codes"/> of this document
-		      </t>
-		    </list>
-		  </t>
-		  <t>
-		    <list style="hanging">
-		      <t>Error Code: setType</t>
-		      <t>Description: An unexpected Event type was received</t>
-		      <t>Change Controller: IETF Secevent Working Group</t>
-		      <t>Defining Document(s): 
-		      <xref target="error_codes"/> of this document
-		      </t>
-		    </list>
-		  </t>
-		  <t>
-		    <list style="hanging">
-		      <t>Error Code: setParse</t>
-		      <t>Description: 
-		      Invalid structure was encountered such as an inability to parse or an
-		      incomplete set of Event claims.
-		      </t>
-		      <t>Change Controller: IETF Secevent Working Group</t>
-		      <t>Defining Document(s): 
-		      <xref target="error_codes"/> of this document
-		      </t>
-		    </list>
-		  </t>
-		  <t>
-		    <list style="hanging">
-		      <t>Error Code: setData</t>
-		      <t>Description: SET claims incomplete or invalid</t>
-		      <t>Change Controller: IETF Secevent Working Group</t>
-		      <t>Defining Document(s): 
-		      <xref target="error_codes"/> of this document
-		      </t>
-		    </list>
-		  </t>
-		  <t>
-		    <list style="hanging">
-		      <t>Error Code: dup</t>
-		      <t>Description:  A duplicate SET was received and has been ignored.
-		      </t>
+                      <t>Error Code: access_denied</t>
+                      <t>Description: The SET Transmitter is not authorized to transmit the provided
+                          SET to the SET Recipient.</t>
 		      <t>Change Controller: IETF Secevent Working Group</t>
 		      <t>Defining Document(s): 
 		      <xref target="error_codes"/> of this document
@@ -595,10 +535,7 @@ Content-Type: application/json
     <back>
         <references title="Normative References">
             <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.2119.xml' ?>
-            <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.3986.xml' ?>
             <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.5246.xml' ?><!-- TLS 1.2 -->
-
-            <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.5988.xml' ?>
 
             <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.6125.xml' ?><!-- TLS Certs -->
 
@@ -607,7 +544,6 @@ Content-Type: application/json
             <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.7231.xml' ?><!-- HTTP Semantics -->
             <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.7515.xml' ?><!-- JWS -->
             <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.7516.xml' ?><!-- JWE -->
-            <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.7517.xml' ?><!-- JWK -->
             <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.7519.xml' ?><!-- JWT -->
             <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.7525.xml' ?><!-- TLS Recos -->
 
@@ -617,18 +553,7 @@ Content-Type: application/json
         </references>
 
         <references title="Informative References">
-            <?rfc include='http://xml2rfc.tools.ietf.org/public/rfc/bibxml/reference.RFC.3339.xml' ?>
-
-            <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.6749.xml' ?><!-- OAuth -->
-            <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.6750.xml' ?><!-- OAuth Bearer-->
-
-            <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.7521.xml' ?><!-- Client Auth Assertions -->
-
-            <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.7230.xml' ?><!-- HTTP Msg -->
             <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.7235.xml' ?><!-- HTTP Auth -->
-
-            <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.7617.xml' ?><!-- Basic Auth Update -->
-
         </references>
 
         <section title="Other Streaming Specifications">
@@ -758,6 +683,19 @@ Content-Type: application/json
 		  Updated Marius' contact information.
 		</t>
 	      </list>
+            </t>
+            <t>
+                Draft 04 - AB:
+                <list style="symbols">
+                    <t>Replaced Error Codes with smaller set of meaningfully differentiated codes.</t>
+                    <t>Added more error response examples.</t>
+                    <t>Removed un-referenced normative references.</t>
+                    <t>Added normative reference to JSON in error response definition.</t>
+                    <t>
+                        Added text clarifying that the value of the <spanx style="verb">description</spanx>
+                        attribute in error responses is implementation specific.
+                    </t>
+                </list>
             </t>
         </section>
     </back>

--- a/draft-ietf-secevent-http-push.xml
+++ b/draft-ietf-secevent-http-push.xml
@@ -194,6 +194,11 @@
                     <xref target="RFC7519">JWT</xref>.
                 </t>
                 <t>
+                    The SET Transmitter MAY include in the request an <spanx style="verb">Accept-Language</spanx>
+                    header to indicate to the SET Recipient the preferred language(s) in which to
+                    receive error messages.
+                </t>
+                <t>
                     The mechanisms by which the SET Transmitter determines the HTTP endpoint to
                     use when transmitting a SET to a given SET Recipient are not defined by this
                     specification and may be implementation-specific.
@@ -205,6 +210,7 @@
                     <artwork align="left">POST /Events  HTTP/1.1
 Host: notify.rp.example.com
 Accept: application/json
+Accept-Language: en-US, en;q=0.5
 Content-Type: application/secevent+jwt
 
 eyJhbGciOiJub25lIn0
@@ -255,24 +261,37 @@ tZSI6Impkb2UiLCJpZCI6IjQ0ZjYxNDJkZjk2YmQ2YWI2MWU3NTIxZDkiLCJuYW
                     validating a SET transmitted in a SET Transmission Request,
                     the SET Recipient SHALL respond with an HTTP Response Status Code
                     of 400 (Bad Request).  The <spanx style="verb">Content-Type</spanx> header of this
-                    response MUST be "application/json", and the body MUST be a <xref target="RFC7159">JSON</xref>
+                    response MUST be "application/json", and the body MUST be a UTF-8 encoded <xref target="RFC7159">JSON</xref>
                     object containing the following name/value pairs:
                     <list style="hanging">
                         <t hangText="err">
                             A Security Event Token Error Code (see <xref target="error_codes"/>).
                         </t>
                         <t hangText="description">
-                            Human-readable text that describes the error and MAY contain
-                            additional diagnostic information. The exact content of this
-                            field is implementation-specific.
+                            A UTF-8 string containing a human-readable description of the error
+                            that MAY provide additional diagnostic information. The exact content
+                            of this field is implementation-specific.
                         </t>
                     </list>
                 </t>
 
+                <t>
+                    The response MUST include a <spanx style="verb">Content-Language</spanx> header, whose
+                    value indicates the language of the error descriptions included in the response body. If
+                    the SET Recipient can provide error descriptions in multiple languages, they SHOULD choose
+                    the language to use according to the value of the <spanx style="verb">Accept-Language</spanx>
+                    header sent by the SET Transmitter in the transmission request, as described in Section 5.3.5
+                    of <xref target="RFC7231"/>. If the SET Transmitter did not send an
+                    <spanx style="verb">Accept-Language</spanx> header, or if the SET Recipient does not support any
+                    of the languages included in the header, the SET Recipient MUST respond with messages that are
+                    understandable by an English-speaking person, as described in Section 4.5 of <xref target="RFC2277"/>.
+                </t>
+                    
                 <figure anchor="errorResponseInvalidKey" title="Example Error Response (invalid_key)">
                     <preamble>The following is an example non-normative error response indicating
                         that the key used to encrypt the SET has been revoked.</preamble>
                     <artwork>HTTP/1.1 400 Bad Request
+Content-Language: en-US
 Content-Type: application/json
 
 {
@@ -285,6 +304,7 @@ Content-Type: application/json
                     <preamble>The following is an example non-normative error response indicating
                         that the access token included in the request is expired.</preamble>
                     <artwork>HTTP/1.1 400 Bad Request
+Content-Language: en-US
 Content-Type: application/json
 
 {
@@ -298,6 +318,7 @@ Content-Type: application/json
                         that the SET Transmitter is not permitted to transmit SETs issued by the
                         issuer specified in the SET.</preamble>
                     <artwork>HTTP/1.1 400 Bad Request
+Content-Language: en-US
 Content-Type: application/json
 
 {
@@ -550,6 +571,7 @@ Content-Type: application/json
             <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.8126.xml' ?>
             <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.8174.xml' ?>
             <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.8417.xml'?><!-- SET -->
+            <?rfc include='http://xml.resource.org/public/rfc/bibxml/reference.RFC.2277.xml'?><!-- IETF Language Policy -->
         </references>
 
         <references title="Informative References">
@@ -694,6 +716,11 @@ Content-Type: application/json
                     <t>
                         Added text clarifying that the value of the <spanx style="verb">description</spanx>
                         attribute in error responses is implementation specific.
+                    </t>
+                    <t>Added requirement that error descriptions and responses are UTF-8 encoded.</t>
+                    <t>
+                        Added error description language preferences and specification via <spanx style="verb">Accept-Language</spanx>
+                        and <spanx style="verb">Content-Language</spanx> headers.
                     </t>
                 </list>
             </t>


### PR DESCRIPTION
This PR addresses comments made at IETF 103:

- Error Code revisions:
  - Replaced Error Codes with smaller set of meaningfully differentiated codes.
  - Added more error response examples.
  - Added text clarifying that the value of the description attribute in error responses is implementation specific.
- Error description message languages:
  - Added requirement that error descriptions and responses are UTF-8 encoded.
  - Added error description language preferences and specification via Accept-Language and Content-Language headers.
