### PR TITLE
Updates based on comments received from WG

### DIFF
--- a/draft-ietf-secevent-http-push.html
+++ b/draft-ietf-secevent-http-push.html
@@ -386,7 +386,7 @@
 <link href="#rfc.section.4" rel="Chapter" title="4 Delivery Reliability">
 <link href="#rfc.section.5" rel="Chapter" title="5 Security Considerations">
 <link href="#rfc.section.5.1" rel="Chapter" title="5.1 Authentication Using Signed SETs">
-<link href="#rfc.section.5.2" rel="Chapter" title="5.2 TLS Support Considerations">
+<link href="#rfc.section.5.2" rel="Chapter" title="5.2 Confidentiality of SETs">
 <link href="#rfc.section.5.3" rel="Chapter" title="5.3 Denial of Service">
 <link href="#rfc.section.5.4" rel="Chapter" title="5.4 Authenticating Persisted SETs">
 <link href="#rfc.section.6" rel="Chapter" title="6 Privacy Considerations">
@@ -408,7 +408,7 @@
 
   <meta name="dct.creator" content="Backman, A., Ed., Jones, M., Ed., Scurtescu, M., Ansari, M., and A. Nadalin" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-secevent-http-push-04" />
-  <meta name="dct.issued" scheme="ISO8601" content="2019-24" />
+  <meta name="dct.issued" scheme="ISO8601" content="2019-11" />
   <meta name="dct.abstract" content="This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  " />
   <meta name="description" content="This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  " />
 
@@ -432,7 +432,7 @@
 <td class="right">M. Jones, Ed.</td>
 </tr>
 <tr>
-<td class="left">Expires: July 28, 2019</td>
+<td class="left">Expires: September 12, 2019</td>
 <td class="right">Microsoft</td>
 </tr>
 <tr>
@@ -461,7 +461,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">January 24, 2019</td>
+<td class="right">March 11, 2019</td>
 </tr>
 
     	
@@ -477,7 +477,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on July 28, 2019.</p>
+<p>This Internet-Draft will expire on September 12, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2019 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -511,7 +511,7 @@
 </li>
 <ul><li>5.1.   <a href="#rfc.section.5.1">Authentication Using Signed SETs</a>
 </li>
-<li>5.2.   <a href="#rfc.section.5.2">TLS Support Considerations</a>
+<li>5.2.   <a href="#rfc.section.5.2">Confidentiality of SETs</a>
 </li>
 <li>5.3.   <a href="#rfc.section.5.3">Denial of Service</a>
 </li>
@@ -558,7 +558,7 @@
 </ul>
 
 <p> </p>
-<p id="rfc.section.1.p.3">A mechanism for exchanging configuration metadata such as endpoint URLs and cryptographic key parameters between the transmitter and receipt is out of scope for this specifications.  </p>
+<p id="rfc.section.1.p.3">A mechanism for exchanging configuration metadata such as endpoint URLs and cryptographic key parameters between the transmitter and recipient is out of scope for this specifications.  </p>
 <h1 id="rfc.section.1.1">
 <a href="#rfc.section.1.1">1.1.</a> <a href="#notat" id="notat">Notational Conventions</a>
 </h1>
@@ -573,46 +573,48 @@
 <dl>
 <dt>SET Transmitter</dt>
 <dd style="margin-left: 8">
-<br> An entity that delivers SETs in its possession to one or more SET Recipients, as defined in <a href="#RFC8417" class="xref">[RFC8417]</a>.  </dd>
+<br> An entity that delivers SETs in its possession to one or more SET Recipients.  </dd>
 <dt>SET Recipient</dt>
 <dd style="margin-left: 8">
-<br> An entity that receives SETs through some distribution method, as defined in <a href="#RFC8417" class="xref">[RFC8417]</a>.  </dd>
+<br> An entity that receives SETs through some distribution method.  </dd>
 </dl>
 
 <p> </p>
 <h1 id="rfc.section.2">
 <a href="#rfc.section.2">2.</a> SET Delivery</h1>
-<p id="rfc.section.2.p.1">To deliver a SET to a given SET Recipient, the SET Transmitter makes a SET Transmission Request to the SET Recipient, with the SET itself contained within the request. The SET Recipient replies to this request with a response either acknowledging successful transmission of the SET, or indicating that an error occurred while receiving, parsing, and/or validating the SET.  </p>
+<p id="rfc.section.2.p.1">To deliver a SET to a given SET Recipient, the SET Transmitter makes a SET transmission request to the SET Recipient, with the SET itself contained within the request. The SET Recipient replies to this request with a response either acknowledging successful transmission of the SET or indicating that an error occurred while receiving, parsing, and/or validating the SET.  </p>
 <p id="rfc.section.2.p.2">Upon receipt of a SET, the SET Recipient SHALL validate that all of the following are true: </p>
 
 <ul>
 <li>The SET Recipient can parse the SET.</li>
 <li>The SET is authentic (i.e., it was issued by the issuer specified within the SET).  </li>
 <li>The SET Recipient is identified as an intended audience of the SET.  </li>
-<li>The SET issuer is recognized as an issuer that the SET Recipient is willing to receive SETs from (e.g., the issuer is whitelisted by the SET Recipient).  </li>
+<li>The SET Issuer is recognized as an issuer that the SET Recipient is willing to receive SETs from (e.g., the issuer is whitelisted by the SET Recipient).  </li>
+<li>The SET Recipient is willing to accept the SET when transmitted by the SET Transmitter (e.g., the SET Transmitter is expected to send SETs with the subject of the SET in question).  </li>
 </ul>
 
 <p> </p>
-<p id="rfc.section.2.p.3">The mechanisms by which the SET Recipient performs this validation are out of scope for this document. SET parsing and issuer and audience identification are defined in <a href="#RFC8417" class="xref">[RFC8417]</a>.  The mechanism for validating the authenticity of a SET is implementation specific, and may vary depending on the authentication mechanisms in use, and whether the SET is signed and/or encrypted (See <a href="#aa" class="xref">Section 3</a>).  </p>
-<p id="rfc.section.2.p.4">The SET Recipient SHOULD ensure that the SET is persisted in a way that is sufficient to meet the SET Recipient's own reliability requirements, and MUST NOT expect or depend on a SET Transmitter to re-transmit or otherwise make available to the SET Recipient a SET once the SET Recipient acknowledges that it was received successfully.  </p>
-<p id="rfc.section.2.p.5">Once the SET has been validated and persisted, the SET Recipient SHOULD immediately return a response indicating that the SET was successfully delivered. The SET Recipient SHOULD NOT perform extensive business logic that processes the event expressed by the SET prior to sending this response.  Such logic SHOULD be executed asynchronously from delivery, in order to minimize the expense and impact of SET delivery on the SET Transmitter.  </p>
-<p id="rfc.section.2.p.6">The SET Transmitter MAY re-transmit a SET if the responses from previous transmissions timed out or indicated potentially recoverable error (such as server unavailability that may be transient, or a decryption failure that may be due to misconfigured keys on the SET Recipient's side). In all other cases, the SET Transmitter SHOULD NOT re-transmit a SET. The SET Transmitter SHOULD delay retransmission for an appropriate amount of time to avoid overwhelming the SET Recipient (see <a href="#reliability" class="xref">Section 4</a>).  </p>
+<p id="rfc.section.2.p.3">The mechanisms by which the SET Recipient performs this validation are out of scope for this document. SET parsing and issuer and audience identification are defined in <a href="#RFC8417" class="xref">[RFC8417]</a>.  The mechanism for validating the authenticity of a SET is deployment specific, and may vary depending on the authentication mechanisms in use, and whether the SET is signed and/or encrypted (See <a href="#aa" class="xref">Section 3</a>).  </p>
+<p id="rfc.section.2.p.4">SET Transmitters MAY transmit SETs issued by another entity. The SET Recipient may accept or reject (i.e., return an <samp>access_denied</samp> error response) at its own discretion.  </p>
+<p id="rfc.section.2.p.5">The SET Recipient SHOULD ensure that the SET is persisted in a way that is sufficient to meet the SET Recipient's own reliability requirements, and MUST NOT expect or depend on a SET Transmitter to re-transmit or otherwise make available to the SET Recipient a SET once the SET Recipient acknowledges that it was received successfully.  </p>
+<p id="rfc.section.2.p.6">Once the SET has been validated and persisted, the SET Recipient SHOULD immediately return a response indicating that the SET was successfully delivered. The SET Recipient SHOULD NOT perform extensive business logic that processes the event expressed by the SET prior to sending this response.  Such logic SHOULD be executed asynchronously from delivery, in order to minimize the expense and impact of SET delivery on the SET Transmitter.  </p>
+<p id="rfc.section.2.p.7">The SET Transmitter MAY re-transmit a SET if the responses from previous transmissions timed out or indicated potentially recoverable error (such as server unavailability that may be transient). In all other cases, the SET Transmitter SHOULD NOT re-transmit a SET. The SET Transmitter SHOULD delay retransmission for an appropriate amount of time to avoid overwhelming the SET Recipient (see <a href="#reliability" class="xref">Section 4</a>).  </p>
 <h1 id="rfc.section.2.1">
 <a href="#rfc.section.2.1">2.1.</a> <a href="#httpPost" id="httpPost">Transmitting a SET</a>
 </h1>
 <p id="rfc.section.2.1.p.1">To transmit a SET to a SET Recipient, the SET Transmitter makes an HTTP POST request to an HTTP endpoint provided by the SET Recipient.  The <samp>Content-Type</samp> header of this request MUST be "application/secevent+jwt" as defined in Sections 2.2 and 6.2 of <a href="#RFC8417" class="xref">[RFC8417]</a>, and the <samp>Accept</samp> header MUST be "application/json".  The request body MUST consist of the SET itself, represented as a <a href="#RFC7519" class="xref">JWT</a>.  </p>
 <p id="rfc.section.2.1.p.2">The SET Transmitter MAY include in the request an <samp>Accept-Language</samp> header to indicate to the SET Recipient the preferred language(s) in which to receive error messages.  </p>
-<p id="rfc.section.2.1.p.3">The mechanisms by which the SET Transmitter determines the HTTP endpoint to use when transmitting a SET to a given SET Recipient are not defined by this specification and may be implementation-specific.  </p>
+<p id="rfc.section.2.1.p.3">The mechanisms by which the SET Transmitter determines the HTTP endpoint to use when transmitting a SET to a given SET Recipient are not defined by this specification and are deployment specific.  </p>
 <div id="rfc.figure.1"></div>
 <div id="postSet"></div>
 <p>The following is a non-normative example of a SET transmission request: </p>
-<pre>POST /Events  HTTP/1.1
+<pre>POST /Events HTTP/1.1
 Host: notify.rp.example.com
 Accept: application/json
 Accept-Language: en-US, en;q=0.5
 Content-Type: application/secevent+jwt
 
-eyJhbGciOiJub25lIn0
+eyJ0eXAiOiJzZWNldmVudCtqd3QiLCJhbGciOiJIUzI1NiJ9Cg
 .
 eyJwdWJsaXNoZXJVcmkiOiJodHRwczovL3NjaW0uZXhhbXBsZS5jb20iLCJmZWV
 kVXJpcyI6WyJodHRwczovL2podWIuZXhhbXBsZS5jb20vRmVlZHMvOThkNTI0Nj
@@ -624,24 +626,24 @@ VzIjpbImlkIiwibmFtZSIsInVzZXJOYW1lIiwicGFzc3dvcmQiLCJlbWFpbHMiX
 SwidmFsdWVzIjp7ImVtYWlscyI6W3sidHlwZSI6IndvcmsiLCJ2YWx1ZSI6Impk
 b2VAZXhhbXBsZS5jb20ifV0sInBhc3N3b3JkIjoibm90NHUybm8iLCJ1c2VyTmF
 tZSI6Impkb2UiLCJpZCI6IjQ0ZjYxNDJkZjk2YmQ2YWI2MWU3NTIxZDkiLCJuYW
-1lIjp7ImdpdmVuTmFtZSI6IkpvaG4iLCJmYW1pbHlOYW1lIjoiRG9lIn19fQ
+1lIjp7ImdpdmVuTmFtZSI6IkpvaG4iLCJmYW1pbHlOYW1lIjoiRG9lIn19fQo
 .
-c2lnbmF0dXJl</pre>
+Y4rXxMD406P2edv00cr9Wf3/XwNtLjB9n+jTqN1/lLc</pre>
 <p class="figure">Figure 1: Example SET Transmission Request</p>
 <h1 id="rfc.section.2.2">
 <a href="#rfc.section.2.2">2.2.</a> <a href="#successResponse" id="successResponse">Success Response</a>
 </h1>
-<p id="rfc.section.2.2.p.1">If the SET is determined to be valid, the SET Recipient SHALL "acknowledge" successful transmission by responding with HTTP Response Status Code 202 (Accepted) (see Section 6.3.3 of <a href="#RFC7231" class="xref">[RFC7231]</a>).  The body of the response MUST be empty.  </p>
+<p id="rfc.section.2.2.p.1">If the SET is determined to be valid, the SET Recipient SHALL acknowledge successful transmission by responding with HTTP Response Status Code 202 (Accepted) (see Section 6.3.3 of <a href="#RFC7231" class="xref">[RFC7231]</a>).  The body of the response MUST be empty.  </p>
 <div id="rfc.figure.2"></div>
 <div id="goodPostResponse"></div>
 <p>The following is a non-normative example of a successful receipt of a SET.</p>
 <pre>HTTP/1.1 202 Accepted</pre>
 <p class="figure">Figure 2: Example Successful Delivery Response</p>
-<p id="rfc.section.2.2.p.2">Note that the purpose of the "acknowledgement" response is to let the SET Transmitter know that a SET has been delivered and the information no longer needs to be retained by the SET Transmitter.  Before acknowledgement, SET Recipients SHOULD ensure they have validated received SETs and retained them in a manner appropriate to information retention requirements appropriate to the SET event types signaled. The level and method of retention of SETs by SET Recipients is out of scope of this specification.</p>
+<p id="rfc.section.2.2.p.2">Note that the purpose of the acknowledgement response is to let the SET Transmitter know that a SET has been delivered and the information no longer needs to be retained by the SET Transmitter.  Before acknowledgement, SET Recipients SHOULD ensure they have validated received SETs and retained them in a manner appropriate to information retention requirements appropriate to the SET event types signaled. The level and method of retention of SETs by SET Recipients is out of scope of this specification.</p>
 <h1 id="rfc.section.2.3">
 <a href="#rfc.section.2.3">2.3.</a> <a href="#failureResponse" id="failureResponse">Failure Response</a>
 </h1>
-<p id="rfc.section.2.3.p.1">In the event of a general HTTP error condition, the SET Recipient MAY respond with an appropriate HTTP Status Code as defined in Section 6 of <a href="#RFC7231" class="xref">[RFC7231]</a>.</p>
+<p id="rfc.section.2.3.p.1">In the event of a general HTTP error condition, the SET Recipient SHOULD respond with an appropriate HTTP Status Code as defined in Section 6 of <a href="#RFC7231" class="xref">[RFC7231]</a>.</p>
 <p id="rfc.section.2.3.p.2">When the SET Recipient detects an error parsing or validating a SET transmitted in a SET Transmission Request, the SET Recipient SHALL respond with an HTTP Response Status Code of 400 (Bad Request).  The <samp>Content-Type</samp> header of this response MUST be "application/json", and the body MUST be a UTF-8 encoded <a href="#RFC7159" class="xref">JSON</a> object containing the following name/value pairs: </p>
 
 <dl>
@@ -679,7 +681,7 @@ Content-Type: application/json
 <p class="figure">Figure 4: Example Error Response (authentication_failed)</p>
 <div id="rfc.figure.5"></div>
 <div id="errorResponseBadIssuer"></div>
-<p>The following is an example non-normative error response indicating that the SET Transmitter is not permitted to transmit SETs issued by the issuer specified in the SET.</p>
+<p>The following is an example non-normative error response indicating that the SET Receiver is not willing to accept SETs issued by the specified issuer from this particular SET Transmitter.</p>
 <pre>HTTP/1.1 400 Bad Request
 Content-Language: en-US
 Content-Type: application/json
@@ -724,8 +726,8 @@ Content-Type: application/json
 <h1 id="rfc.section.3">
 <a href="#rfc.section.3">3.</a> <a href="#aa" id="aa">Authentication and Authorization</a>
 </h1>
-<p id="rfc.section.3.p.1">The SET delivery method described in this specification is based upon HTTP and depends on the use of TLS and/or standard HTTP authentication and authorization schemes as per <a href="#RFC7235" class="xref">[RFC7235]</a>.  </p>
-<p id="rfc.section.3.p.2">Because SET Delivery describes a simple function, authorization for the ability to pick-up or deliver SETs can be derived by considering the identity of the SET issuer, or via other employed authentication methods.  Because SETs are not commands, SET Recipients are free to ignore SETs that are not of interest.</p>
+<p id="rfc.section.3.p.1">The SET delivery method described in this specification is based upon HTTP and depends on the use of TLS and/or standard HTTP authentication and authorization schemes, as per <a href="#RFC7235" class="xref">[RFC7235]</a>.  </p>
+<p id="rfc.section.3.p.2">Because SET Delivery describes a simple function, authorization for the ability to pick-up or deliver SETs can be derived by considering the identity of the SET Issuer, or via other employed authentication methods.  Because SETs are not commands, SET Recipients are free to ignore SETs that are not of interest.</p>
 <h1 id="rfc.section.4">
 <a href="#rfc.section.4">4.</a> <a href="#reliability" id="reliability">Delivery Reliability</a>
 </h1>
@@ -737,28 +739,29 @@ Content-Type: application/json
 <h1 id="rfc.section.5.1">
 <a href="#rfc.section.5.1">5.1.</a> <a href="#payloadAuthentication" id="payloadAuthentication">Authentication Using Signed SETs</a>
 </h1>
-<p id="rfc.section.5.1.p.1">In scenarios where HTTP authorization or TLS mutual authentication are not used or are considered weak, JWS signed SETs SHOULD be used (see <a href="#RFC7515" class="xref">[RFC7515]</a> and <a href="#RFC8417" class="xref">Security Considerations</a>). This enables the SET Recipient to validate that the SET issuer is authorized to deliver the SET.  </p>
+<p id="rfc.section.5.1.p.1">In scenarios where HTTP authorization or TLS mutual authentication are not used or are considered weak, JWS signed SETs SHOULD be used (see <a href="#RFC7515" class="xref">[RFC7515]</a> and <a href="#RFC8417" class="xref">Security Considerations</a>). This enables the SET Recipient to validate that the SET Issuer is authorized to deliver the SET.  </p>
 <h1 id="rfc.section.5.2">
-<a href="#rfc.section.5.2">5.2.</a> TLS Support Considerations</h1>
-<p id="rfc.section.5.2.p.1">SETs may contain sensitive information that is considered PII (e.g., subject claims). In such cases, SET Transmitters and SET Recipients MUST require the use of a transport-layer security mechanism. Event delivery endpoints MUST support TLS 1.2 <a href="#RFC5246" class="xref">[RFC5246]</a> and MAY support additional transport-layer mechanisms meeting its security requirements.  When using TLS, the client MUST perform a TLS/SSL server certificate check, per <a href="#RFC6125" class="xref">[RFC6125]</a>. Implementation security considerations for TLS can be found in "Recommendations for Secure Use of TLS and DTLS" <a href="#RFC7525" class="xref">[RFC7525]</a>.</p>
+<a href="#rfc.section.5.2">5.2.</a> Confidentiality of SETs</h1>
+<p id="rfc.section.5.2.p.1">SETs may contain sensitive information that is considered PII (e.g., subject claims). In such cases, SET Transmitters and SET Recipients MUST protect the confidentiality of the SET contents by encrypting the SET as described in <a href="#RFC7516" class="xref">JWE</a>, using a transport-layer security mechanism such as TLS, or both. If an Event delivery endpoint supports TLS, it MUST support at least TLS version 1.2 <a href="#RFC5246" class="xref">[RFC5246]</a> and SHOULD support the newest version of TLS that meets its security requirements. When using TLS, the client MUST perform a TLS/SSL server certificate check, per <a href="#RFC6125" class="xref">[RFC6125]</a>.  Implementation security considerations for TLS can be found in "Recommendations for Secure Use of TLS and DTLS" <a href="#RFC7525" class="xref">[RFC7525]</a>.</p>
 <h1 id="rfc.section.5.3">
 <a href="#rfc.section.5.3">5.3.</a> Denial of Service</h1>
 <p id="rfc.section.5.3.p.1">The SET Recipient may be vulnerable to a denial-of-service attack where a malicious party makes a high volume of requests containing invalid SETs, causing the endpoint to expend significant resources on cryptographic operations that are bound to fail. This may be mitigated by authenticating SET Transmitters with a mechanism with low runtime overhead, such as mutual TLS.  </p>
 <h1 id="rfc.section.5.4">
 <a href="#rfc.section.5.4">5.4.</a> Authenticating Persisted SETs</h1>
-<p id="rfc.section.5.4.p.1">At the time of receipt, the SET Recipient can rely upon transport layer mechanisms, HTTP authentication methods, and/or other context from the transmission request to authenticate the SET Transmitter and validate the authenticity of the SET.  However, this context is typically unavailable to systems that the SET Recipient forwards the SET onto, or to systems that retrieve the SET from storage.  If the SET Recipient requires the ability to validate SET authenticity outside of the context of the transmission request, then the SET Transmitter SHOULD sign the SET in accordance with <a href="#RFC7515" class="xref">[RFC7515]</a> and optionally also encrypt it in accordance with <a href="#RFC7516" class="xref">[RFC7516]</a>.  </p>
+<p id="rfc.section.5.4.p.1">At the time of receipt, the SET Recipient can rely upon transport layer mechanisms, HTTP authentication methods, and/or other context from the transmission request to authenticate the SET Transmitter and validate the authenticity of the SET.  However, this context is typically unavailable to systems that the SET Recipient forwards the SET onto, or to systems that retrieve the SET from storage.  If the SET Recipient requires the ability to validate SET authenticity outside of the context of the transmission request, then the SET Transmitter SHOULD sign the SET in accordance with <a href="#RFC7515" class="xref">[RFC7515]</a> and/or encrypt it using authenticated encryption in accordance with <a href="#RFC7516" class="xref">[RFC7516]</a>.  </p>
 <h1 id="rfc.section.6">
 <a href="#rfc.section.6">6.</a> Privacy Considerations</h1>
 <p id="rfc.section.6.p.1">If a SET needs to be retained for audit purposes, a JWS signature MAY be used to provide verification of its authenticity.</p>
 <p id="rfc.section.6.p.2">When sharing personally identifiable information or information that is otherwise considered confidential to affected users, SET Transmitters and Recipients MUST have the appropriate legal agreements and user consent or terms of service in place.</p>
-<p id="rfc.section.6.p.3">The propagation of subject identifiers can be perceived as personally identifiable information. Where possible, SET Transmitters and Recipients SHOULD devise approaches that prevent propagation -- for example, the passing of a hash value that requires the subscriber to already know the subject.</p>
+<p id="rfc.section.6.p.3">In some cases subject identifiers themselves may be considered sensitive information, such that its inclusion within a SET may be considered a violation of privacy.  SET Transmitters should consider the ramifications of sharing a particular subject identifier with a SET Recipient (e.g., whether doing so could enable correlation and/or de-anonymization of data), and choose appropriate subject identifiers for their use case.</p>
 <h1 id="rfc.section.7">
 <a href="#rfc.section.7">7.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
 </h1>
 <h1 id="rfc.section.7.1">
 <a href="#rfc.section.7.1">7.1.</a> <a href="#iana_set_errors" id="iana_set_errors">Security Event Token Delivery Error Codes</a>
 </h1>
-<p id="rfc.section.7.1.p.1">This document defines Security Event Token Delivery Error Codes, for which IANA is asked to create and maintain a new registry titled "Security Event Token Delivery Error Codes".  Initial values for the Security Event Token Delivery Error Codes registry are given in <a href="#reqErrors" class="xref">Table 1</a>.  Future assignments are to be made through the Expert Review registration policy (<a href="#RFC8126" class="xref">[RFC8126]</a>) and shall follow the template presented in <a href="#iana_set_errors_template" class="xref">Section 7.1.1</a>.  </p>
+<p id="rfc.section.7.1.p.1">This document defines Security Event Token Delivery Error Codes, for which IANA is asked to create and maintain a new registry titled "Security Event Token Delivery Error Codes".  Initial values for the Security Event Token Delivery Error Codes registry are given in <a href="#reqErrors" class="xref">Table 1</a>.  Future assignments are to be made through the First Come First Served registration policy (<a href="#RFC8126" class="xref">[RFC8126]</a>) and shall follow the template presented in <a href="#iana_set_errors_template" class="xref">Section 7.1.1</a>.  </p>
+<p id="rfc.section.7.1.p.2">Error Codes are intended to be interpreted by automated systems, and therefore SHOULD identify classes of errors to which an automated system could respond in a meaningfully distinct way (e.g., by refreshing authentication credentials and retrying the request).  </p>
 <h1 id="rfc.section.7.1.1">
 <a href="#rfc.section.7.1.1">7.1.1.</a> <a href="#iana_set_errors_template" id="iana_set_errors_template">Registration Template</a>
 </h1>
@@ -767,13 +770,13 @@ Content-Type: application/json
 <dl>
 <dt>Error Code</dt>
 <dd style="margin-left: 8">
-<br> The name of the Security Event Token Delivery Error Code, as described in <a href="#error_codes" class="xref">Section 2.4</a>. The name MUST be a case-sensitive ASCII string consisting only of upper-case letters ("A" - "Z"), lower-case letters ("a" - "z"), and digits ("0" - "9").  </dd>
+<br> The name of the Security Event Token Delivery Error Code, as described in <a href="#error_codes" class="xref">Section 2.4</a>. The name MUST be a case-sensitive ASCII string consisting only of characters whose codes fall within the inclusive ranges 0x20-23, 0x25-5B, and 0x5D-7E.  </dd>
 <dt>Description</dt>
 <dd style="margin-left: 8">
 <br> A brief human-readable description of the Security Event Token Delivery Error Code.  </dd>
 <dt>Change Controller</dt>
 <dd style="margin-left: 8">
-<br> For error codes registered by the IETF or its working groups, list "IETF Secevent Working Group".  For all other error codes, list the name of the party responsible for the registration.  Contact information such as mailing address, email address, or phone number may also be provided.  </dd>
+<br> For error codes registered by the IETF or its working groups, list "IETF SecEvent Working Group".  For all other error codes, list the name of the party responsible for the registration.  Contact information such as mailing address, email address, or phone number may also be provided.  </dd>
 <dt>Defining Document(s)</dt>
 <dd style="margin-left: 8">
 <br> A reference to the document or documents that define the Security Event Token Delivery Error Code. The definition MUST specify the name and description of the error code, and explain under what circumstances the error code may be used. URIs that can be used to retrieve copies of each document at no cost SHOULD be included.  </dd>
@@ -788,7 +791,7 @@ Content-Type: application/json
 <dt></dt>
 <dd style="margin-left: 8">Error Code: invalid_request</dd>
 <dt></dt>
-<dd style="margin-left: 8">Description: The request body cannot be parsed as a SET, or the event payload within the SET does not conform to the event's definition.</dd>
+<dd style="margin-left: 8">Description: The request body cannot be parsed as a SET or the event payload within the SET does not conform to the event's definition.</dd>
 <dt></dt>
 <dd style="margin-left: 8">Change Controller: IETF Secevent Working Group</dd>
 <dt></dt>
@@ -830,7 +833,7 @@ Content-Type: application/json
 <dt></dt>
 <dd style="margin-left: 8">Error Code: access_denied</dd>
 <dt></dt>
-<dd style="margin-left: 8">Description: The SET Transmitter is not authorized to transmit the provided SET to the SET Recipient.</dd>
+<dd style="margin-left: 8">Description: The SET Transmitter is not authorized to transmit the SET to the SET Recipient.</dd>
 <dt></dt>
 <dd style="margin-left: 8">Change Controller: IETF Secevent Working Group</dd>
 <dt></dt>
@@ -920,21 +923,28 @@ Content-Type: application/json
 <a href="#rfc.appendix.A">Appendix A.</a> Other Streaming Specifications</h1>
 <p id="rfc.section.A.p.1">[[EDITORS NOTE: This section to be removed prior to publication]]</p>
 <p id="rfc.section.A.p.2">The following pub/sub, queuing, streaming systems were reviewed as possible solutions or as input to the current draft:</p>
-<p id="rfc.section.A.p.3">XMPP Events</p>
-<p id="rfc.section.A.p.4">The WG considered the XMPP events ands its ability to provide a single messaging solution without the need for both polling and push modes.  The feeling was the size and methodology of XMPP was to far apart from the current capabilities of the SECEVENTs community which focuses in on HTTP based service delivery and authorization.</p>
-<p id="rfc.section.A.p.5">Amazon Simple Notification Service</p>
-<p id="rfc.section.A.p.6">Simple Notification Service, is a pub/sub messaging product from AWS. SNS supports a variety of subscriber types: HTTP/HTTPS endpoints, AWS Lambda functions, email addresses (as JSON or plain text), phone numbers (via SMS), and AWS SQS standard queues. It doesn&#8217;t directly support pull, but subscribers can get the pull model by creating an SQS queue and subscribing it to the topic. Note that this puts the cost of pull support back onto the subscriber, just as it is in the push model. It is not clear that one way is strictly better than the other; larger, sophisticated developers may be happy to own message persistence so they can have their own internal delivery guarantees.  The long tail of OIDC clients may not care about that, or may fail to get it right. Regardless, I think we can learn something from the Delivery Policies supported by SNS, as well as the delivery controls that SQS offers (e.g., Visibility Timeout, Dead-Letter Queues). I&#8217;m not suggesting that we need all of these things in the spec, but they give an idea of what features people have found useful.</p>
-<p id="rfc.section.A.p.7">Other information:</p>
+<p id="rfc.section.A.p.3">Poll-Based Security Event Token (SET) Delivery Using HTTP</p>
+<p id="rfc.section.A.p.4">In addition to this specification, the WG is defining a polling-based SET delivery protocol. That protocol's draft (draft-ietf-secevent-http-poll) describes it as:</p>
+<pre>This specification defines how a series of Security Event Tokens
+(SETs) may be delivered to an intended recipient using HTTP POST over
+TLS initiated as a poll by the recipient.  The specification also
+defines how delivery can be assured, subject to the SET Recipient's
+need for assurance.</pre>
+<p id="rfc.section.A.p.5">XMPP Events</p>
+<p id="rfc.section.A.p.6">The WG considered the XMPP events ands its ability to provide a single messaging solution without the need for both polling and push modes.  The feeling was the size and methodology of XMPP was to far apart from the current capabilities of the SECEVENTs community which focuses in on HTTP based service delivery and authorization.</p>
+<p id="rfc.section.A.p.7">Amazon Simple Notification Service</p>
+<p id="rfc.section.A.p.8">Simple Notification Service, is a pub/sub messaging product from AWS. SNS supports a variety of subscriber types: HTTP/HTTPS endpoints, AWS Lambda functions, email addresses (as JSON or plain text), phone numbers (via SMS), and AWS SQS standard queues. It doesn&#8217;t directly support pull, but subscribers can get the pull model by creating an SQS queue and subscribing it to the topic. Note that this puts the cost of pull support back onto the subscriber, just as it is in the push model. It is not clear that one way is strictly better than the other; larger, sophisticated developers may be happy to own message persistence so they can have their own internal delivery guarantees.  The long tail of OIDC clients may not care about that, or may fail to get it right. Regardless, I think we can learn something from the Delivery Policies supported by SNS, as well as the delivery controls that SQS offers (e.g., Visibility Timeout, Dead-Letter Queues). I&#8217;m not suggesting that we need all of these things in the spec, but they give an idea of what features people have found useful.</p>
+<p id="rfc.section.A.p.9">Other information:</p>
 
 <ul>
 <li>API Reference: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/Welcome.html</li>
 <li>Visibility Timeouts: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html</li>
 </ul>
-<p id="rfc.section.A.p.8">Apache Kafka</p>
-<p id="rfc.section.A.p.9">Apache Kafka is an Apache open source project based upon TCP for distributed streaming. It prescribes some interesting general purpose features that seem to extend far beyond the simpler streaming model SECEVENTs is after. A comment from MS has been that Kafka does an acknowledge with poll combination event which seems to be a performance advantage. See: https://kafka.apache.org/intro</p>
-<p id="rfc.section.A.p.10">Google Pub/Sub</p>
-<p id="rfc.section.A.p.11">Google Pub Sub system favours a model whereby polling and acknowledgement of events is done as separate endpoints as separate functions.</p>
-<p id="rfc.section.A.p.12">Information:</p>
+<p id="rfc.section.A.p.10">Apache Kafka</p>
+<p id="rfc.section.A.p.11">Apache Kafka is an Apache open source project based upon TCP for distributed streaming. It prescribes some interesting general purpose features that seem to extend far beyond the simpler streaming model SECEVENTs is after. A comment from MS has been that Kafka does an acknowledge with poll combination event which seems to be a performance advantage. See: https://kafka.apache.org/intro</p>
+<p id="rfc.section.A.p.12">Google Pub/Sub</p>
+<p id="rfc.section.A.p.13">Google Pub Sub system favours a model whereby polling and acknowledgement of events is done as separate endpoints as separate functions.</p>
+<p id="rfc.section.A.p.14">Information:</p>
 
 <ul>
 <li>Cloud Overview - https://cloud.google.com/pubsub/</li>
@@ -943,9 +953,9 @@ Content-Type: application/json
 </ul>
 <h1 id="rfc.appendix.B">
 <a href="#rfc.appendix.B">Appendix B.</a> Acknowledgments</h1>
-<p id="rfc.section.B.p.1">The editors would like to thank the members of the SCIM working group, which began discussions of provisioning events starting with: draft-hunt-scim-notify-00 in 2015.</p>
+<p id="rfc.section.B.p.1">The editors would like to thank the members of the SCIM working group, which began discussions of provisioning events starting with draft-hunt-scim-notify-00 in 2015.</p>
 <p id="rfc.section.B.p.2">The editors would like to thank Phil Hunt and the other authors of draft-ietf-secevent-delivery-02, on which this draft is based.</p>
-<p id="rfc.section.B.p.3">The editors would like to thank the participants in the the SECEVENTS working group for their contributions to this specification.</p>
+<p id="rfc.section.B.p.3">The editors would like to thank the participants in the the SecEvents working group for their contributions to this specification.</p>
 <h1 id="rfc.appendix.C">
 <a href="#rfc.appendix.C">Appendix C.</a> <a href="#History" id="History">Change Log</a>
 </h1>
@@ -1020,6 +1030,26 @@ Content-Type: application/json
 <li>Added time outs as an acceptable reason to resend a SET in section 2.</li>
 <li>Edited text in section 1 to clarify that configuration is out of scope.</li>
 <li>Made minor editorial corrections.</li>
+</ul>
+
+<p> </p>
+<p id="rfc.section.C.p.6">Draft 05 - AB: </p>
+
+<ul>
+<li>Made minor editorial corrections.</li>
+<li>Updated example request with a correct SET header and signature.</li>
+<li>Revised TLS guidance to allow implementers to provide confidentiality protection via JWE.</li>
+<li>Revised TLS guidance to require *at least* TLS 1.2.</li>
+<li>Revised TLS guidance to recommend supporting the newest version of TLS that meets security requirements.</li>
+<li>Revised SET Delivery Error Code format to allow the same set of characters as is allowed in error codes in RFC6749.</li>
+<li>Added mention of HTTP Poll spec to list of other streaming specs in appendix.</li>
+<li>Added validation step requiring SET Recipient to verify that the SET is one which the SET Transmitter is expected to send to the SET Recipient.</li>
+<li>Changed responding to errors with an appropriate HTTP status code from optional to recommended.</li>
+<li>Changed Error Codes registry change policy from Expert Review to First Come First Served; added guidance that error codes are meant to be consumed by automated systems.</li>
+<li>Added text making clear that it is up to SET Recipients whether or not they will accept SETs where the SET Issuer is different from the SET Transmitter.</li>
+<li>Reworded guidance around signing and/or encrypting SETs for integrity protection.</li>
+<li>Renamed TLS "Support Considerations" section to "Confidentiality of SETs".</li>
+<li>Reworded guidance around subject identifier selection and privacy concerns.</li>
 </ul>
 
 <p> </p>

--- a/draft-ietf-secevent-http-push.html
+++ b/draft-ietf-secevent-http-push.html
@@ -407,7 +407,7 @@
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Backman, A., Ed., Jones, M., Ed., Scurtescu, M., Ansari, M., and A. Nadalin" />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-secevent-http-push-04" />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-secevent-http-push-05" />
   <meta name="dct.issued" scheme="ISO8601" content="2019-11" />
   <meta name="dct.abstract" content="This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  " />
   <meta name="description" content="This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  " />
@@ -469,7 +469,7 @@
   </table>
 
   <p class="title">Push-Based Security Event Token (SET) Delivery Using HTTP<br />
-  <span class="filename">draft-ietf-secevent-http-push-04</span></p>
+  <span class="filename">draft-ietf-secevent-http-push-05</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  </p>

--- a/draft-ietf-secevent-http-push.txt
+++ b/draft-ietf-secevent-http-push.txt
@@ -16,7 +16,7 @@ Expires: September 12, 2019                                    Microsoft
 
 
        Push-Based Security Event Token (SET) Delivery Using HTTP
-                    draft-ietf-secevent-http-push-04
+                    draft-ietf-secevent-http-push-05
 
 Abstract
 

--- a/draft-ietf-secevent-http-push.txt
+++ b/draft-ietf-secevent-http-push.txt
@@ -5,14 +5,14 @@
 Security Events Working Group                            A. Backman, Ed.
 Internet-Draft                                                    Amazon
 Intended status: Standards Track                           M. Jones, Ed.
-Expires: July 27, 2019                                         Microsoft
+Expires: September 12, 2019                                    Microsoft
                                                             M. Scurtescu
                                                                 Coinbase
                                                                M. Ansari
                                                                    Cisco
                                                               A. Nadalin
                                                                Microsoft
-                                                        January 23, 2019
+                                                          March 11, 2019
 
 
        Push-Based Security Event Token (SET) Delivery Using HTTP
@@ -41,7 +41,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on July 27, 2019.
+   This Internet-Draft will expire on September 12, 2019.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Backman, et al.           Expires July 27, 2019                 [Page 1]
+Backman, et al.        Expires September 12, 2019               [Page 1]
 
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
 
 
    (https://trustee.ietf.org/license-info) in effect on the date of
@@ -72,29 +72,29 @@ Table of Contents
      1.1.  Notational Conventions  . . . . . . . . . . . . . . . . .   3
      1.2.  Definitions . . . . . . . . . . . . . . . . . . . . . . .   3
    2.  SET Delivery  . . . . . . . . . . . . . . . . . . . . . . . .   3
-     2.1.  Transmitting a SET  . . . . . . . . . . . . . . . . . . .   4
-     2.2.  Success Response  . . . . . . . . . . . . . . . . . . . .   5
+     2.1.  Transmitting a SET  . . . . . . . . . . . . . . . . . . .   5
+     2.2.  Success Response  . . . . . . . . . . . . . . . . . . . .   6
      2.3.  Failure Response  . . . . . . . . . . . . . . . . . . . .   6
-     2.4.  Security Event Token Delivery Error Codes . . . . . . . .   7
+     2.4.  Security Event Token Delivery Error Codes . . . . . . . .   8
    3.  Authentication and Authorization  . . . . . . . . . . . . . .   8
-   4.  Delivery Reliability  . . . . . . . . . . . . . . . . . . . .   8
+   4.  Delivery Reliability  . . . . . . . . . . . . . . . . . . . .   9
    5.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
      5.1.  Authentication Using Signed SETs  . . . . . . . . . . . .   9
-     5.2.  TLS Support Considerations  . . . . . . . . . . . . . . .   9
-     5.3.  Denial of Service . . . . . . . . . . . . . . . . . . . .   9
+     5.2.  Confidentiality of SETs . . . . . . . . . . . . . . . . .   9
+     5.3.  Denial of Service . . . . . . . . . . . . . . . . . . . .  10
      5.4.  Authenticating Persisted SETs . . . . . . . . . . . . . .  10
    6.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .  10
    7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
      7.1.  Security Event Token Delivery Error Codes . . . . . . . .  10
-       7.1.1.  Registration Template . . . . . . . . . . . . . . . .  10
+       7.1.1.  Registration Template . . . . . . . . . . . . . . . .  11
        7.1.2.  Initial Registry Contents . . . . . . . . . . . . . .  11
    8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  12
      8.1.  Normative References  . . . . . . . . . . . . . . . . . .  12
      8.2.  Informative References  . . . . . . . . . . . . . . . . .  13
-   Appendix A.  Other Streaming Specifications . . . . . . . . . . .  13
+   Appendix A.  Other Streaming Specifications . . . . . . . . . . .  14
    Appendix B.  Acknowledgments  . . . . . . . . . . . . . . . . . .  15
-   Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  15
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  18
+   Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  16
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  19
 
 1.  Introduction and Overview
 
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Backman, et al.           Expires July 27, 2019                 [Page 2]
+Backman, et al.        Expires September 12, 2019               [Page 2]
 
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
 
 
    o  The transmitter of the SET is capable of making outbound HTTP
@@ -124,7 +124,7 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
 
    A mechanism for exchanging configuration metadata such as endpoint
    URLs and cryptographic key parameters between the transmitter and
-   receipt is out of scope for this specifications.
+   recipient is out of scope for this specifications.
 
 1.1.  Notational Conventions
 
@@ -144,33 +144,31 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
 
    SET Transmitter
       An entity that delivers SETs in its possession to one or more SET
-      Recipients, as defined in [RFC8417].
+      Recipients.
 
    SET Recipient
-      An entity that receives SETs through some distribution method, as
-      defined in [RFC8417].
+      An entity that receives SETs through some distribution method.
 
 2.  SET Delivery
 
    To deliver a SET to a given SET Recipient, the SET Transmitter makes
-   a SET Transmission Request to the SET Recipient, with the SET itself
+   a SET transmission request to the SET Recipient, with the SET itself
    contained within the request.  The SET Recipient replies to this
    request with a response either acknowledging successful transmission
-   of the SET, or indicating that an error occurred while receiving,
+   of the SET or indicating that an error occurred while receiving,
    parsing, and/or validating the SET.
 
    Upon receipt of a SET, the SET Recipient SHALL validate that all of
    the following are true:
 
-
-
-
-Backman, et al.           Expires July 27, 2019                 [Page 3]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
-
    o  The SET Recipient can parse the SET.
+
+
+
+Backman, et al.        Expires September 12, 2019               [Page 3]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
 
    o  The SET is authentic (i.e., it was issued by the issuer specified
       within the SET).
@@ -178,16 +176,24 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    o  The SET Recipient is identified as an intended audience of the
       SET.
 
-   o  The SET issuer is recognized as an issuer that the SET Recipient
+   o  The SET Issuer is recognized as an issuer that the SET Recipient
       is willing to receive SETs from (e.g., the issuer is whitelisted
       by the SET Recipient).
+
+   o  The SET Recipient is willing to accept the SET when transmitted by
+      the SET Transmitter (e.g., the SET Transmitter is expected to send
+      SETs with the subject of the SET in question).
 
    The mechanisms by which the SET Recipient performs this validation
    are out of scope for this document.  SET parsing and issuer and
    audience identification are defined in [RFC8417].  The mechanism for
-   validating the authenticity of a SET is implementation specific, and
-   may vary depending on the authentication mechanisms in use, and
-   whether the SET is signed and/or encrypted (See Section 3).
+   validating the authenticity of a SET is deployment specific, and may
+   vary depending on the authentication mechanisms in use, and whether
+   the SET is signed and/or encrypted (See Section 3).
+
+   SET Transmitters MAY transmit SETs issued by another entity.  The SET
+   Recipient may accept or reject (i.e., return an "access_denied" error
+   response) at its own discretion.
 
    The SET Recipient SHOULD ensure that the SET is persisted in a way
    that is sufficient to meet the SET Recipient's own reliability
@@ -206,26 +212,25 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
 
    The SET Transmitter MAY re-transmit a SET if the responses from
    previous transmissions timed out or indicated potentially recoverable
-   error (such as server unavailability that may be transient, or a
-   decryption failure that may be due to misconfigured keys on the SET
-   Recipient's side).  In all other cases, the SET Transmitter SHOULD
-   NOT re-transmit a SET.  The SET Transmitter SHOULD delay
-   retransmission for an appropriate amount of time to avoid
-   overwhelming the SET Recipient (see Section 4).
+   error (such as server unavailability that may be transient).  In all
+   other cases, the SET Transmitter SHOULD NOT re-transmit a SET.  The
+   SET Transmitter SHOULD delay retransmission for an appropriate amount
+   of time to avoid overwhelming the SET Recipient (see Section 4).
+
+
+
+
+
+Backman, et al.        Expires September 12, 2019               [Page 4]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
 
 2.1.  Transmitting a SET
 
    To transmit a SET to a SET Recipient, the SET Transmitter makes an
    HTTP POST request to an HTTP endpoint provided by the SET Recipient.
    The "Content-Type" header of this request MUST be "application/
-
-
-
-Backman, et al.           Expires July 27, 2019                 [Page 4]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
-
    secevent+jwt" as defined in Sections 2.2 and 6.2 of [RFC8417], and
    the "Accept" header MUST be "application/json".  The request body
    MUST consist of the SET itself, represented as a JWT [RFC7519].
@@ -236,18 +241,18 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
 
    The mechanisms by which the SET Transmitter determines the HTTP
    endpoint to use when transmitting a SET to a given SET Recipient are
-   not defined by this specification and may be implementation-specific.
+   not defined by this specification and are deployment specific.
 
    The following is a non-normative example of a SET transmission
    request:
 
-   POST /Events  HTTP/1.1
+   POST /Events HTTP/1.1
    Host: notify.rp.example.com
    Accept: application/json
    Accept-Language: en-US, en;q=0.5
    Content-Type: application/secevent+jwt
 
-   eyJhbGciOiJub25lIn0
+   eyJ0eXAiOiJzZWNldmVudCtqd3QiLCJhbGciOiJIUzI1NiJ9Cg
    .
    eyJwdWJsaXNoZXJVcmkiOiJodHRwczovL3NjaW0uZXhhbXBsZS5jb20iLCJmZWV
    kVXJpcyI6WyJodHRwczovL2podWIuZXhhbXBsZS5jb20vRmVlZHMvOThkNTI0Nj
@@ -259,28 +264,30 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    SwidmFsdWVzIjp7ImVtYWlscyI6W3sidHlwZSI6IndvcmsiLCJ2YWx1ZSI6Impk
    b2VAZXhhbXBsZS5jb20ifV0sInBhc3N3b3JkIjoibm90NHUybm8iLCJ1c2VyTmF
    tZSI6Impkb2UiLCJpZCI6IjQ0ZjYxNDJkZjk2YmQ2YWI2MWU3NTIxZDkiLCJuYW
-   1lIjp7ImdpdmVuTmFtZSI6IkpvaG4iLCJmYW1pbHlOYW1lIjoiRG9lIn19fQ
+   1lIjp7ImdpdmVuTmFtZSI6IkpvaG4iLCJmYW1pbHlOYW1lIjoiRG9lIn19fQo
    .
-   c2lnbmF0dXJl
+   Y4rXxMD406P2edv00cr9Wf3/XwNtLjB9n+jTqN1/lLc
 
                 Figure 1: Example SET Transmission Request
+
+
+
+
+
+
+
+
+Backman, et al.        Expires September 12, 2019               [Page 5]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
 
 2.2.  Success Response
 
    If the SET is determined to be valid, the SET Recipient SHALL
-   "acknowledge" successful transmission by responding with HTTP
-   Response Status Code 202 (Accepted) (see Section 6.3.3 of [RFC7231]).
-   The body of the response MUST be empty.
-
-
-
-
-
-
-Backman, et al.           Expires July 27, 2019                 [Page 5]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
+   acknowledge successful transmission by responding with HTTP Response
+   Status Code 202 (Accepted) (see Section 6.3.3 of [RFC7231]).  The
+   body of the response MUST be empty.
 
    The following is a non-normative example of a successful receipt of a
    SET.
@@ -289,7 +296,7 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
 
               Figure 2: Example Successful Delivery Response
 
-   Note that the purpose of the "acknowledgement" response is to let the
+   Note that the purpose of the acknowledgement response is to let the
    SET Transmitter know that a SET has been delivered and the
    information no longer needs to be retained by the SET Transmitter.
    Before acknowledgement, SET Recipients SHOULD ensure they have
@@ -300,9 +307,9 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
 
 2.3.  Failure Response
 
-   In the event of a general HTTP error condition, the SET Recipient MAY
-   respond with an appropriate HTTP Status Code as defined in Section 6
-   of [RFC7231].
+   In the event of a general HTTP error condition, the SET Recipient
+   SHOULD respond with an appropriate HTTP Status Code as defined in
+   Section 6 of [RFC7231].
 
    When the SET Recipient detects an error parsing or validating a SET
    transmitted in a SET Transmission Request, the SET Recipient SHALL
@@ -323,20 +330,19 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    in multiple languages, they SHOULD choose the language to use
    according to the value of the "Accept-Language" header sent by the
    SET Transmitter in the transmission request, as described in
+
+
+
+Backman, et al.        Expires September 12, 2019               [Page 6]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
+
    Section 5.3.5 of [RFC7231].  If the SET Transmitter did not send an
    "Accept-Language" header, or if the SET Recipient does not support
    any of the languages included in the header, the SET Recipient MUST
    respond with messages that are understandable by an English-speaking
    person, as described in Section 4.5 of [RFC2277].
-
-
-
-
-
-Backman, et al.           Expires July 27, 2019                 [Page 6]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
 
    The following is an example non-normative error response indicating
    that the key used to encrypt the SET has been revoked.
@@ -367,8 +373,8 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
          Figure 4: Example Error Response (authentication_failed)
 
    The following is an example non-normative error response indicating
-   that the SET Transmitter is not permitted to transmit SETs issued by
-   the issuer specified in the SET.
+   that the SET Receiver is not willing to accept SETs issued by the
+   specified issuer from this particular SET Transmitter.
 
    HTTP/1.1 400 Bad Request
    Content-Language: en-US
@@ -381,19 +387,18 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
 
              Figure 5: Example Error Response (access_denied)
 
+
+
+Backman, et al.        Expires September 12, 2019               [Page 7]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
+
 2.4.  Security Event Token Delivery Error Codes
 
    Security Event Token Delivery Error Codes are strings that identify a
    specific category of error that may occur when parsing or validating
    a SET.  Every Security Event Token Delivery Error Code MUST have a
-
-
-
-Backman, et al.           Expires July 27, 2019                 [Page 7]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
-
    unique name registered in the IANA "Security Event Token Delivery
    Error Codes" registry established by Section 7.1.
 
@@ -427,13 +432,23 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
 
    The SET delivery method described in this specification is based upon
    HTTP and depends on the use of TLS and/or standard HTTP
-   authentication and authorization schemes as per [RFC7235].
+   authentication and authorization schemes, as per [RFC7235].
 
    Because SET Delivery describes a simple function, authorization for
    the ability to pick-up or deliver SETs can be derived by considering
-   the identity of the SET issuer, or via other employed authentication
+   the identity of the SET Issuer, or via other employed authentication
    methods.  Because SETs are not commands, SET Recipients are free to
    ignore SETs that are not of interest.
+
+
+
+
+
+
+Backman, et al.        Expires September 12, 2019               [Page 8]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
 
 4.  Delivery Reliability
 
@@ -442,14 +457,6 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    Recipient in such a way as to provide the SET Transmitter with the
    information necessary to determine what further action is required,
    if any, in order to meet their requirements.  SET Transmitters with
-
-
-
-Backman, et al.           Expires July 27, 2019                 [Page 8]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
-
    high reliability requirements may be tempted to always retry failed
    transmissions, however it should be noted that for many types of SET
    delivery errors, a retry is extremely unlikely to be successful.  For
@@ -471,20 +478,33 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    In scenarios where HTTP authorization or TLS mutual authentication
    are not used or are considered weak, JWS signed SETs SHOULD be used
    (see [RFC7515] and Security Considerations [RFC8417]).  This enables
-   the SET Recipient to validate that the SET issuer is authorized to
+   the SET Recipient to validate that the SET Issuer is authorized to
    deliver the SET.
 
-5.2.  TLS Support Considerations
+5.2.  Confidentiality of SETs
 
    SETs may contain sensitive information that is considered PII (e.g.,
    subject claims).  In such cases, SET Transmitters and SET Recipients
-   MUST require the use of a transport-layer security mechanism.  Event
-   delivery endpoints MUST support TLS 1.2 [RFC5246] and MAY support
-   additional transport-layer mechanisms meeting its security
-   requirements.  When using TLS, the client MUST perform a TLS/SSL
-   server certificate check, per [RFC6125].  Implementation security
-   considerations for TLS can be found in "Recommendations for Secure
-   Use of TLS and DTLS" [RFC7525].
+   MUST protect the confidentiality of the SET contents by encrypting
+   the SET as described in JWE [RFC7516], using a transport-layer
+   security mechanism such as TLS, or both.  If an Event delivery
+   endpoint supports TLS, it MUST support at least TLS version 1.2
+   [RFC5246] and SHOULD support the newest version of TLS that meets its
+   security requirements.  When using TLS, the client MUST perform a
+   TLS/SSL server certificate check, per [RFC6125].  Implementation
+   security considerations for TLS can be found in "Recommendations for
+   Secure Use of TLS and DTLS" [RFC7525].
+
+
+
+
+
+
+
+Backman, et al.        Expires September 12, 2019               [Page 9]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
 
 5.3.  Denial of Service
 
@@ -494,17 +514,6 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    cryptographic operations that are bound to fail.  This may be
    mitigated by authenticating SET Transmitters with a mechanism with
    low runtime overhead, such as mutual TLS.
-
-
-
-
-
-
-
-Backman, et al.           Expires July 27, 2019                 [Page 9]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
 
 5.4.  Authenticating Persisted SETs
 
@@ -516,8 +525,9 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    SET onto, or to systems that retrieve the SET from storage.  If the
    SET Recipient requires the ability to validate SET authenticity
    outside of the context of the transmission request, then the SET
-   Transmitter SHOULD sign the SET in accordance with [RFC7515] and
-   optionally also encrypt it in accordance with [RFC7516].
+   Transmitter SHOULD sign the SET in accordance with [RFC7515] and/or
+   encrypt it using authenticated encryption in accordance with
+   [RFC7516].
 
 6.  Privacy Considerations
 
@@ -529,11 +539,13 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    Transmitters and Recipients MUST have the appropriate legal
    agreements and user consent or terms of service in place.
 
-   The propagation of subject identifiers can be perceived as personally
-   identifiable information.  Where possible, SET Transmitters and
-   Recipients SHOULD devise approaches that prevent propagation -- for
-   example, the passing of a hash value that requires the subscriber to
-   already know the subject.
+   In some cases subject identifiers themselves may be considered
+   sensitive information, such that its inclusion within a SET may be
+   considered a violation of privacy.  SET Transmitters should consider
+   the ramifications of sharing a particular subject identifier with a
+   SET Recipient (e.g., whether doing so could enable correlation and/or
+   de-anonymization of data), and choose appropriate subject identifiers
+   for their use case.
 
 7.  IANA Considerations
 
@@ -542,25 +554,31 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    This document defines Security Event Token Delivery Error Codes, for
    which IANA is asked to create and maintain a new registry titled
    "Security Event Token Delivery Error Codes".  Initial values for the
+
+
+
+Backman, et al.        Expires September 12, 2019              [Page 10]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
+
    Security Event Token Delivery Error Codes registry are given in
-   Table 1.  Future assignments are to be made through the Expert Review
-   registration policy ([RFC8126]) and shall follow the template
-   presented in Section 7.1.1.
+   Table 1.  Future assignments are to be made through the First Come
+   First Served registration policy ([RFC8126]) and shall follow the
+   template presented in Section 7.1.1.
+
+   Error Codes are intended to be interpreted by automated systems, and
+   therefore SHOULD identify classes of errors to which an automated
+   system could respond in a meaningfully distinct way (e.g., by
+   refreshing authentication credentials and retrying the request).
 
 7.1.1.  Registration Template
 
    Error Code
       The name of the Security Event Token Delivery Error Code, as
       described in Section 2.4.  The name MUST be a case-sensitive ASCII
-      string consisting only of upper-case letters ("A" - "Z"), lower-
-      case letters ("a" - "z"), and digits ("0" - "9").
-
-
-
-Backman, et al.           Expires July 27, 2019                [Page 10]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
+      string consisting only of characters whose codes fall within the
+      inclusive ranges 0x20-23, 0x25-5B, and 0x5D-7E.
 
    Description
       A brief human-readable description of the Security Event Token
@@ -568,7 +586,7 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
 
    Change Controller
       For error codes registered by the IETF or its working groups, list
-      "IETF Secevent Working Group".  For all other error codes, list
+      "IETF SecEvent Working Group".  For all other error codes, list
       the name of the party responsible for the registration.  Contact
       information such as mailing address, email address, or phone
       number may also be provided.
@@ -583,13 +601,23 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
 7.1.2.  Initial Registry Contents
 
       Error Code: invalid_request
-      Description: The request body cannot be parsed as a SET, or the
+      Description: The request body cannot be parsed as a SET or the
       event payload within the SET does not conform to the event's
       definition.
       Change Controller: IETF Secevent Working Group
       Defining Document(s): Section 2.4 of this document
 
       Error Code: invalid_key
+
+
+
+
+
+Backman, et al.        Expires September 12, 2019              [Page 11]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
+
       Description: One or more keys used to encrypt or sign the SET is
       invalid or otherwise unacceptable to the SET Recipient. (e.g.,
       expired, revoked, failed certificate validation, etc.)
@@ -604,19 +632,9 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
 
       Error Code: access_denied
       Description: The SET Transmitter is not authorized to transmit the
-      provided SET to the SET Recipient.
+      SET to the SET Recipient.
       Change Controller: IETF Secevent Working Group
       Defining Document(s): Section 2.4 of this document
-
-
-
-
-
-
-Backman, et al.           Expires July 27, 2019                [Page 11]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
 
 8.  References
 
@@ -647,6 +665,15 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
               Interchange Format", RFC 7159, DOI 10.17487/RFC7159, March
               2014, <https://www.rfc-editor.org/info/rfc7159>.
 
+
+
+
+
+Backman, et al.        Expires September 12, 2019              [Page 12]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
+
    [RFC7231]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
               Protocol (HTTP/1.1): Semantics and Content", RFC 7231,
               DOI 10.17487/RFC7231, June 2014,
@@ -663,16 +690,6 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    [RFC7519]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web Token
               (JWT)", RFC 7519, DOI 10.17487/RFC7519, May 2015,
               <https://www.rfc-editor.org/info/rfc7519>.
-
-
-
-
-
-
-Backman, et al.           Expires July 27, 2019                [Page 12]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
 
    [RFC7525]  Sheffer, Y., Holz, R., and P. Saint-Andre,
               "Recommendations for Secure Use of Transport Layer
@@ -701,12 +718,36 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
               DOI 10.17487/RFC7235, June 2014,
               <https://www.rfc-editor.org/info/rfc7235>.
 
+
+
+
+
+
+
+
+Backman, et al.        Expires September 12, 2019              [Page 13]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
+
 Appendix A.  Other Streaming Specifications
 
    [[EDITORS NOTE: This section to be removed prior to publication]]
 
    The following pub/sub, queuing, streaming systems were reviewed as
    possible solutions or as input to the current draft:
+
+   Poll-Based Security Event Token (SET) Delivery Using HTTP
+
+   In addition to this specification, the WG is defining a polling-based
+   SET delivery protocol.  That protocol's draft (draft-ietf-secevent-
+   http-poll) describes it as:
+
+   This specification defines how a series of Security Event Tokens
+   (SETs) may be delivered to an intended recipient using HTTP POST over
+   TLS initiated as a poll by the recipient.  The specification also
+   defines how delivery can be assured, subject to the SET Recipient's
+   need for assurance.
 
    XMPP Events
 
@@ -722,14 +763,6 @@ Appendix A.  Other Streaming Specifications
    SNS supports a variety of subscriber types: HTTP/HTTPS endpoints, AWS
    Lambda functions, email addresses (as JSON or plain text), phone
    numbers (via SMS), and AWS SQS standard queues.  It doesn't directly
-
-
-
-Backman, et al.           Expires July 27, 2019                [Page 13]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
-
    support pull, but subscribers can get the pull model by creating an
    SQS queue and subscribing it to the topic.  Note that this puts the
    cost of pull support back onto the subscriber, just as it is in the
@@ -744,6 +777,14 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    give an idea of what features people have found useful.
 
    Other information:
+
+
+
+
+Backman, et al.        Expires September 12, 2019              [Page 14]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
 
    o  API Reference:
       http://docs.aws.amazon.com/AWSSimpleQueueService/latest/
@@ -777,26 +818,29 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
 
    o  Subscriber Pull(poll) - https://cloud.google.com/pubsub/docs/pull
 
-
-
-
-
-Backman, et al.           Expires July 27, 2019                [Page 14]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
-
 Appendix B.  Acknowledgments
 
    The editors would like to thank the members of the SCIM working
-   group, which began discussions of provisioning events starting with:
+   group, which began discussions of provisioning events starting with
    draft-hunt-scim-notify-00 in 2015.
 
    The editors would like to thank Phil Hunt and the other authors of
    draft-ietf-secevent-delivery-02, on which this draft is based.
 
-   The editors would like to thank the participants in the the SECEVENTS
+   The editors would like to thank the participants in the the SecEvents
    working group for their contributions to this specification.
+
+
+
+
+
+
+
+
+Backman, et al.        Expires September 12, 2019              [Page 15]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
 
 Appendix C.  Change Log
 
@@ -833,15 +877,6 @@ Appendix C.  Change Log
    o  Removed further generally applicable guidance for authorization
       tokens.
 
-
-
-
-
-Backman, et al.           Expires July 27, 2019                [Page 15]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
-
    o  Removed bearer token from example delivery request, and text
       referencing it.
 
@@ -854,6 +889,14 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    o  Removed unapplicable notes about example formatting.
 
    o  Removed text about SET creation and handling.
+
+
+
+
+Backman, et al.        Expires September 12, 2019              [Page 16]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
 
    o  Removed duplication in protocol description.
 
@@ -889,15 +932,6 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    o  Added retry guidance, notes regarding delivery reliability
       requirements.
 
-
-
-
-
-Backman, et al.           Expires July 27, 2019                [Page 16]
-
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
-
-
    o  Added guidance around using JWS and/or JWE to authenticate
       persisted SETs.
 
@@ -912,6 +946,13 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
    o  Applied editorial and minor normative corrections.
 
    o  Updated Marius' contact information.
+
+
+
+Backman, et al.        Expires September 12, 2019              [Page 17]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
+
 
    Draft 04 - AB:
 
@@ -943,16 +984,58 @@ Internet-Draft        draft-ietf-secevent-http-push         January 2019
 
    o  Made minor editorial corrections.
 
+   Draft 05 - AB:
+
+   o  Made minor editorial corrections.
+
+   o  Updated example request with a correct SET header and signature.
+
+   o  Revised TLS guidance to allow implementers to provide
+      confidentiality protection via JWE.
+
+   o  Revised TLS guidance to require *at least* TLS 1.2.
+
+   o  Revised TLS guidance to recommend supporting the newest version of
+      TLS that meets security requirements.
+
+   o  Revised SET Delivery Error Code format to allow the same set of
+      characters as is allowed in error codes in RFC6749.
 
 
 
 
 
-
-Backman, et al.           Expires July 27, 2019                [Page 17]
+Backman, et al.        Expires September 12, 2019              [Page 18]
 
-Internet-Draft        draft-ietf-secevent-http-push         January 2019
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
 
+
+   o  Added mention of HTTP Poll spec to list of other streaming specs
+      in appendix.
+
+   o  Added validation step requiring SET Recipient to verify that the
+      SET is one which the SET Transmitter is expected to send to the
+      SET Recipient.
+
+   o  Changed responding to errors with an appropriate HTTP status code
+      from optional to recommended.
+
+   o  Changed Error Codes registry change policy from Expert Review to
+      First Come First Served; added guidance that error codes are meant
+      to be consumed by automated systems.
+
+   o  Added text making clear that it is up to SET Recipients whether or
+      not they will accept SETs where the SET Issuer is different from
+      the SET Transmitter.
+
+   o  Reworded guidance around signing and/or encrypting SETs for
+      integrity protection.
+
+   o  Renamed TLS "Support Considerations" section to "Confidentiality
+      of SETs".
+
+   o  Reworded guidance around subject identifier selection and privacy
+      concerns.
 
 Authors' Addresses
 
@@ -973,6 +1056,14 @@ Authors' Addresses
    Coinbase
 
    Email: marius.scurtescu@coinbase.com
+
+
+
+
+
+Backman, et al.        Expires September 12, 2019              [Page 19]
+
+Internet-Draft        draft-ietf-secevent-http-push           March 2019
 
 
    Morteza Ansari
@@ -1005,4 +1096,25 @@ Authors' Addresses
 
 
 
-Backman, et al.           Expires July 27, 2019                [Page 18]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Backman, et al.        Expires September 12, 2019              [Page 20]

--- a/draft-ietf-secevent-http-push.xml
+++ b/draft-ietf-secevent-http-push.xml
@@ -11,7 +11,7 @@
 <?rfc inline="yes"?>
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
-<rfc category="std" docName="draft-ietf-secevent-http-push-04" ipr="trust200902">
+<rfc category="std" docName="draft-ietf-secevent-http-push-05" ipr="trust200902">
     <front>
         <title abbrev="draft-ietf-secevent-http-push">Push-Based Security Event Token (SET) Delivery Using HTTP</title>
 

--- a/draft-ietf-secevent-http-push.xml
+++ b/draft-ietf-secevent-http-push.xml
@@ -89,7 +89,7 @@
             </t>
             <t>
                 A mechanism for exchanging configuration metadata such as endpoint URLs
-                and cryptographic key parameters between the transmitter and receipt is
+                and cryptographic key parameters between the transmitter and recipient is
                 out of scope for this specifications.
             </t>
             
@@ -116,11 +116,10 @@
                     <list style="hanging">
                         <t hangText="SET Transmitter"><vspace/>
                             An entity that delivers SETs in its possession to one or more SET
-                            Recipients, as defined in <xref target="RFC8417"/>.
+                            Recipients.
                         </t>
                         <t hangText="SET Recipient"><vspace/>
-                            An entity that receives SETs through some distribution method, as 
-                            defined in <xref target="RFC8417"/>.
+                            An entity that receives SETs through some distribution method.
                         </t>
                         
                     </list>
@@ -131,10 +130,10 @@
         <section title="SET Delivery">
             <t>
                 To deliver a SET to a given SET Recipient, the SET Transmitter
-                makes a SET Transmission Request to the SET Recipient, with the SET
+                makes a SET transmission request to the SET Recipient, with the SET
                 itself contained within the request. The SET Recipient replies to
                 this request with a response either acknowledging successful
-                transmission of the SET, or indicating that an error occurred
+                transmission of the SET or indicating that an error occurred
                 while receiving, parsing, and/or validating the SET.
 
             </t>
@@ -152,9 +151,14 @@
                         the SET.
                     </t>
                     <t>
-                        The SET issuer is recognized as an issuer that the SET Recipient
+                        The SET Issuer is recognized as an issuer that the SET Recipient
                         is willing to receive SETs from (e.g., the issuer is whitelisted
                         by the SET Recipient).
+                    </t>
+                    <t>
+                        The SET Recipient is willing to accept the SET when transmitted
+                        by the SET Transmitter (e.g., the SET Transmitter is expected to
+                        send SETs with the subject of the SET in question).
                     </t>
                 </list>
             </t>
@@ -162,9 +166,14 @@
                 The mechanisms by which the SET Recipient performs this validation
                 are out of scope for this document. SET parsing and issuer and
                 audience identification are defined in <xref target="RFC8417"/>.
-                The mechanism for validating the authenticity of a SET is implementation
+                The mechanism for validating the authenticity of a SET is deployment
                 specific, and may vary depending on the authentication mechanisms in
                 use, and whether the SET is signed and/or encrypted (See <xref target="aa"/>).
+            </t>
+            <t>
+                SET Transmitters MAY transmit SETs issued by another entity. The SET
+                Recipient may accept or reject (i.e., return an <spanx style="verb">access_denied</spanx>
+                error response) at its own discretion.
             </t>
             <t>
                 The SET Recipient SHOULD ensure that the SET is persisted in a way that
@@ -184,8 +193,7 @@
             <t>
                 The SET Transmitter MAY re-transmit a SET if the responses from previous
                 transmissions timed out or indicated potentially recoverable error (such
-                as server unavailability that may be transient, or a decryption failure
-                that may be due to misconfigured keys on the SET Recipient's side). In all
+                as server unavailability that may be transient). In all
                 other cases, the SET Transmitter SHOULD NOT re-transmit a SET. The SET
                 Transmitter SHOULD delay retransmission for an appropriate amount of time
                 to avoid overwhelming the SET Recipient (see <xref target="reliability"/>).
@@ -211,19 +219,19 @@
                 <t>
                     The mechanisms by which the SET Transmitter determines the HTTP endpoint to
                     use when transmitting a SET to a given SET Recipient are not defined by this
-                    specification and may be implementation-specific.
+                    specification and are deployment specific.
                 </t>
                 <figure align="left" anchor="postSet" title="Example SET Transmission Request">
                     <preamble>
                         The following is a non-normative example of a SET transmission request:
                     </preamble>
-                    <artwork align="left">POST /Events  HTTP/1.1
+                    <artwork align="left">POST /Events HTTP/1.1
 Host: notify.rp.example.com
 Accept: application/json
 Accept-Language: en-US, en;q=0.5
 Content-Type: application/secevent+jwt
 
-eyJhbGciOiJub25lIn0
+eyJ0eXAiOiJzZWNldmVudCtqd3QiLCJhbGciOiJIUzI1NiJ9Cg
 .
 eyJwdWJsaXNoZXJVcmkiOiJodHRwczovL3NjaW0uZXhhbXBsZS5jb20iLCJmZWV
 kVXJpcyI6WyJodHRwczovL2podWIuZXhhbXBsZS5jb20vRmVlZHMvOThkNTI0Nj
@@ -235,15 +243,15 @@ VzIjpbImlkIiwibmFtZSIsInVzZXJOYW1lIiwicGFzc3dvcmQiLCJlbWFpbHMiX
 SwidmFsdWVzIjp7ImVtYWlscyI6W3sidHlwZSI6IndvcmsiLCJ2YWx1ZSI6Impk
 b2VAZXhhbXBsZS5jb20ifV0sInBhc3N3b3JkIjoibm90NHUybm8iLCJ1c2VyTmF
 tZSI6Impkb2UiLCJpZCI6IjQ0ZjYxNDJkZjk2YmQ2YWI2MWU3NTIxZDkiLCJuYW
-1lIjp7ImdpdmVuTmFtZSI6IkpvaG4iLCJmYW1pbHlOYW1lIjoiRG9lIn19fQ
+1lIjp7ImdpdmVuTmFtZSI6IkpvaG4iLCJmYW1pbHlOYW1lIjoiRG9lIn19fQo
 .
-c2lnbmF0dXJl</artwork>
+Y4rXxMD406P2edv00cr9Wf3/XwNtLjB9n+jTqN1/lLc</artwork>
                 </figure>
             </section>
 
             <section anchor="successResponse" title="Success Response">
                 <t>If the SET is determined to be valid, the SET Recipient SHALL
-                    "acknowledge" successful transmission by responding with HTTP
+                    acknowledge successful transmission by responding with HTTP
                     Response Status Code 202 (Accepted) (see Section 6.3.3 of <xref target="RFC7231"/>).
 		    The body of the response MUST be empty.
                 </t>
@@ -254,7 +262,7 @@ c2lnbmF0dXJl</artwork>
                     <artwork>HTTP/1.1 202 Accepted</artwork>
                 </figure>
 
-                <t>Note that the purpose of the "acknowledgement" response is to let the
+                <t>Note that the purpose of the acknowledgement response is to let the
                     SET Transmitter know that a SET has been delivered and the
                     information no longer needs to be retained by the SET Transmitter.
                     Before acknowledgement, SET Recipients SHOULD ensure they have
@@ -265,7 +273,7 @@ c2lnbmF0dXJl</artwork>
             </section>
             <section anchor="failureResponse" title="Failure Response">
                 <t>In the event of a general HTTP error condition, the SET Recipient
-                    MAY respond with an appropriate HTTP Status Code as defined in
+                    SHOULD respond with an appropriate HTTP Status Code as defined in
                     Section 6 of <xref target="RFC7231"/>.</t>
                 <t>
                     When the SET Recipient detects an error parsing or
@@ -326,8 +334,8 @@ Content-Type: application/json
 
                 <figure anchor="errorResponseBadIssuer" title="Example Error Response (access_denied)">
                     <preamble>The following is an example non-normative error response indicating
-                        that the SET Transmitter is not permitted to transmit SETs issued by the
-                        issuer specified in the SET.</preamble>
+                        that the SET Receiver is not willing to accept SETs issued by the specified
+                        issuer from this particular SET Transmitter.</preamble>
                     <artwork>HTTP/1.1 400 Bad Request
 Content-Language: en-US
 Content-Type: application/json
@@ -366,13 +374,13 @@ Content-Type: application/json
         <section anchor="aa" title="Authentication and Authorization" toc="default">
             <t>The SET delivery method described in this specification is
                 based upon HTTP and depends on the use of TLS and/or standard
-                HTTP authentication and authorization schemes as per
+                HTTP authentication and authorization schemes, as per
                 <xref target="RFC7235" />.
             </t>
 
             <t>Because SET Delivery describes a simple function, authorization
                 for the ability to pick-up or deliver SETs can be derived by
-                considering the identity of the SET issuer, or via other employed
+                considering the identity of the SET Issuer, or via other employed
                 authentication methods.  Because SETs are
                 not commands, SET Recipients are free to ignore SETs that
                 are not of interest.</t>
@@ -406,21 +414,22 @@ Content-Type: application/json
                     are not used or are considered weak, JWS signed SETs SHOULD be
                     used (see <xref target="RFC7515"/> and <xref target="RFC8417">
                     Security Considerations</xref>). This enables the SET Recipient
-                    to validate that the SET issuer is authorized to deliver the SET.
+                    to validate that the SET Issuer is authorized to deliver the SET.
                 </t>
             </section>
 
-            <section title="TLS Support Considerations">
+            <section title="Confidentiality of SETs">
                 <t>SETs may contain sensitive information that is considered PII
                     (e.g., subject claims). In such cases, SET Transmitters and
-                    SET Recipients MUST require the use of a transport-layer
-                    security mechanism. Event delivery endpoints MUST support TLS
-                    1.2 <xref target="RFC5246"/> and MAY support additional
-                    transport-layer mechanisms meeting its security requirements.
-                    When using TLS, the client MUST perform a TLS/SSL server
-                    certificate check, per <xref target="RFC6125"/>. Implementation
-                    security considerations for TLS can be found in "Recommendations for
-                    Secure Use of TLS and DTLS" <xref target="RFC7525"/>.</t>
+                    SET Recipients MUST protect the confidentiality of the SET contents by
+                    encrypting the SET as described in <xref target="RFC7516">JWE</xref>,
+                    using a transport-layer security mechanism such as TLS, or both. If
+                    an Event delivery endpoint supports TLS, it MUST support at least TLS
+                    version 1.2 <xref target="RFC5246"/> and SHOULD support the newest version
+                    of TLS that meets its security requirements. When using TLS, the client MUST
+                    perform a TLS/SSL server certificate check, per <xref target="RFC6125"/>.
+                    Implementation security considerations for TLS can be found in
+                    "Recommendations for Secure Use of TLS and DTLS" <xref target="RFC7525"/>.</t>
             </section>
 
             <section title="Denial of Service">
@@ -444,7 +453,8 @@ Content-Type: application/json
                     retrieve the SET from storage.  If the SET Recipient requires the ability to
                     validate SET authenticity outside of the context of the transmission request,
                     then the SET Transmitter SHOULD sign the SET in accordance with <xref target="RFC7515"/>
-                    and optionally also encrypt it in accordance with <xref target="RFC7516"/>.
+                    and/or encrypt it using authenticated encryption in accordance with
+                    <xref target="RFC7516"/>.
                 </t>
             </section>
         </section>
@@ -458,11 +468,12 @@ Content-Type: application/json
                 Transmitters and Recipients MUST have the appropriate legal agreements
                 and user consent or terms of service in place.</t>
 
-            <t>The propagation of subject identifiers can be perceived as personally
-                identifiable information. Where possible, SET Transmitters and Recipients
-                SHOULD devise approaches that prevent propagation -- for example, the
-                passing of a hash value that requires the subscriber to already know
-                the subject.</t>
+            <t>In some cases subject identifiers themselves may be considered sensitive
+                information, such that its inclusion within a SET may be considered a violation
+                of privacy.  SET Transmitters should consider the ramifications of sharing a
+                particular subject identifier with a SET Recipient (e.g., whether doing so could
+                enable correlation and/or de-anonymization of data), and choose appropriate
+                subject identifiers for their use case.</t>
 
         </section>
 
@@ -473,8 +484,13 @@ Content-Type: application/json
                     is asked to create and maintain a new registry titled "Security Event Token
                     Delivery Error Codes".  Initial values for the Security Event Token Delivery
                     Error Codes registry are given in <xref target="reqErrors"/>.  Future assignments
-                    are to be made through the Expert Review registration policy (<xref target="RFC8126"/>)
+                    are to be made through the First Come First Served registration policy (<xref target="RFC8126"/>)
                     and shall follow the template presented in <xref target="iana_set_errors_template"/>.
+                </t>
+                <t>
+                    Error Codes are intended to be interpreted by automated systems, and therefore SHOULD
+                    identify classes of errors to which an automated system could respond in a meaningfully
+                    distinct way (e.g., by refreshing authentication credentials and retrying the request).
                 </t>
 
                 <section anchor="iana_set_errors_template" title="Registration Template">
@@ -484,8 +500,8 @@ Content-Type: application/json
                                 <vspace/>
                                 The name of the Security Event Token Delivery Error Code, as described
                                 in <xref target="error_codes"/>. The name MUST be a case-sensitive ASCII
-                                string consisting only of upper-case letters ("A" - "Z"), lower-case
-                                letters ("a" - "z"), and digits ("0" - "9").
+                                string consisting only of characters whose codes fall within the inclusive
+                                ranges 0x20-23, 0x25-5B, and 0x5D-7E.
                             </t>
                             <t hangText="Description">
                                 <vspace/>
@@ -495,7 +511,7 @@ Content-Type: application/json
                             <t hangText="Change Controller">
                                 <vspace/>
                                 For error codes registered by the IETF or its working groups, list "IETF
-                                Secevent Working Group".  For all other error codes, list the name of the
+                                SecEvent Working Group".  For all other error codes, list the name of the
                                 party responsible for the registration.  Contact information such as
                                 mailing address, email address, or phone number may also be provided.
                             </t>
@@ -516,7 +532,7 @@ Content-Type: application/json
 		    <?rfc subcompact="yes"?>
 		    <list style="hanging">
 		      <t>Error Code: invalid_request</t>
-                      <t>Description: The request body cannot be parsed as a SET, or the event
+                      <t>Description: The request body cannot be parsed as a SET or the event
                           payload within the SET does not conform to the event's definition.</t>
 		      <t>Change Controller: IETF Secevent Working Group</t>
 		      <t>Defining Document(s): 
@@ -550,7 +566,7 @@ Content-Type: application/json
 		  <t>
 		    <list style="hanging">
                       <t>Error Code: access_denied</t>
-                      <t>Description: The SET Transmitter is not authorized to transmit the provided
+                      <t>Description: The SET Transmitter is not authorized to transmit the 
                           SET to the SET Recipient.</t>
 		      <t>Change Controller: IETF Secevent Working Group</t>
 		      <t>Defining Document(s): 
@@ -594,6 +610,17 @@ Content-Type: application/json
 
             <t>The following pub/sub, queuing, streaming systems were reviewed
                 as possible solutions or as input to the current draft:</t>
+
+            <t>Poll-Based Security Event Token (SET) Delivery Using HTTP</t>
+            <t>In addition to this specification, the WG is defining a polling-based
+                SET delivery protocol. That protocol's draft (draft-ietf-secevent-http-poll)
+                describes it as:</t>
+            <figure><artwork>This specification defines how a series of Security Event Tokens
+(SETs) may be delivered to an intended recipient using HTTP POST over
+TLS initiated as a poll by the recipient.  The specification also
+defines how delivery can be assured, subject to the SET Recipient's
+need for assurance.</artwork>
+            </figure>
 
             <t>XMPP Events</t>
             <t>The WG considered the XMPP events ands its ability to provide a single
@@ -644,12 +671,12 @@ Content-Type: application/json
 
         <section title="Acknowledgments">
             <t>The editors would like to thank the members of the SCIM working group, which
-                began discussions of provisioning events starting with: draft-hunt-scim-notify-00 in 2015.</t>
+                began discussions of provisioning events starting with draft-hunt-scim-notify-00 in 2015.</t>
 
             <t>The editors would like to thank Phil Hunt and the other authors of draft-ietf-secevent-delivery-02,
                 on which this draft is based.</t>
 
-            <t>The editors would like to thank the participants in the the SECEVENTS
+            <t>The editors would like to thank the participants in the the SecEvents
                 working group for their contributions to this specification.</t>
         </section>
 
@@ -737,6 +764,25 @@ Content-Type: application/json
                     <t>Added time outs as an acceptable reason to resend a SET in section 2.</t>
                     <t>Edited text in section 1 to clarify that configuration is out of scope.</t>
                     <t>Made minor editorial corrections.</t>
+                </list>
+            </t>
+            <t>
+                Draft 05 - AB:
+                <list style="symbols">
+                    <t>Made minor editorial corrections.</t>
+                    <t>Updated example request with a correct SET header and signature.</t>
+                    <t>Revised TLS guidance to allow implementers to provide confidentiality protection via JWE.</t>
+                    <t>Revised TLS guidance to require *at least* TLS 1.2.</t>
+                    <t>Revised TLS guidance to recommend supporting the newest version of TLS that meets security requirements.</t>
+                    <t>Revised SET Delivery Error Code format to allow the same set of characters as is allowed in error codes in RFC6749.</t>
+                    <t>Added mention of HTTP Poll spec to list of other streaming specs in appendix.</t>
+                    <t>Added validation step requiring SET Recipient to verify that the SET is one which the SET Transmitter is expected to send to the SET Recipient.</t>
+                    <t>Changed responding to errors with an appropriate HTTP status code from optional to recommended.</t>
+                    <t>Changed Error Codes registry change policy from Expert Review to First Come First Served; added guidance that error codes are meant to be consumed by automated systems.</t>
+                    <t>Added text making clear that it is up to SET Recipients whether or not they will accept SETs where the SET Issuer is different from the SET Transmitter.</t>
+                    <t>Reworded guidance around signing and/or encrypting SETs for integrity protection.</t>
+                    <t>Renamed TLS "Support Considerations" section to "Confidentiality of SETs".</t>
+                    <t>Reworded guidance around subject identifier selection and privacy concerns.</t>
                 </list>
             </t>
         </section>


### PR DESCRIPTION
- Made minor editorial corrections.
- Updated example request with a correct SET header and signature.
- Revised TLS guidance to allow implementers to provide confidentiality protection via JWE.
- Revised TLS guidance to require *at least* TLS 1.2.
- Revised TLS guidance to recommend supporting the newest version of TLS that meets security requirements.
- Reworded guidance around signing and/or encrypting SETs for integrity protection.
- Renamed TLS "Support Considerations" section to "Confidentiality of SETs".
- Revised SET Delivery Error Code format to allow the same set of characters as is allowed in error codes in RFC6749.
- Added mention of HTTP Poll spec to list of other streaming specs in appendix.
- Added validation step requiring SET Recipient to verify that the SET is one which the SET Transmitter is expected to send to the SET Recipient.
- Changed responding to errors with an appropriate HTTP status code from optional to recommended.
- Changed Error Codes registry change policy from Expert Review to First Come First Served; added guidance that error codes are meant to be consumed by automated systems.
- Added text making clear that it is up to SET Recipients whether or not they will accept SETs where the SET Issuer is different from the SET Transmitter.
- Reworded guidance around subject identifier selection and privacy concerns.
