### PR TITLE
Add invalid poll request handling

### DIFF
--- a/draft-ietf-secevent-http-poll.html
+++ b/draft-ietf-secevent-http-poll.html
@@ -412,7 +412,7 @@
 
   <meta name="dct.creator" content="Backman, A., Ed., Jones, M., Ed., Scurtescu, M., Ansari, M., and A. Nadalin" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-secevent-http-poll-04" />
-  <meta name="dct.issued" scheme="ISO8601" content="2019-11-01" />
+  <meta name="dct.issued" scheme="ISO8601" content="2019-11-06" />
   <meta name="dct.abstract" content="This specification defines how a series of Security Event Tokens (SETs) may be delivered to an intended recipient using HTTP POST over TLS initiated as a poll by the recipient. The specification also defines how delivery can be assured, subject to the SET Recipient's need for assurance.  " />
   <meta name="description" content="This specification defines how a series of Security Event Tokens (SETs) may be delivered to an intended recipient using HTTP POST over TLS initiated as a poll by the recipient. The specification also defines how delivery can be assured, subject to the SET Recipient's need for assurance.  " />
 
@@ -436,7 +436,7 @@
 <td class="right">M. Jones, Ed.</td>
 </tr>
 <tr>
-<td class="left">Expires: May 4, 2020</td>
+<td class="left">Expires: May 9, 2020</td>
 <td class="right">Microsoft</td>
 </tr>
 <tr>
@@ -465,7 +465,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">November 1, 2019</td>
+<td class="right">November 6, 2019</td>
 </tr>
 
     	
@@ -481,7 +481,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on May 4, 2020.</p>
+<p>This Internet-Draft will expire on May 9, 2020.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2019 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>

--- a/draft-ietf-secevent-http-poll.html
+++ b/draft-ietf-secevent-http-poll.html
@@ -387,6 +387,7 @@
 <link href="#rfc.section.2.4.3" rel="Chapter" title="2.4.3 Poll with Acknowledgement">
 <link href="#rfc.section.2.4.4" rel="Chapter" title="2.4.4 Poll with Acknowledgement and Errors">
 <link href="#rfc.section.2.5" rel="Chapter" title="2.5 Poll Response">
+<link href="#rfc.section.2.5.1" rel="Chapter" title="2.5.1 Poll Error Response">
 <link href="#rfc.section.2.6" rel="Chapter" title="2.6 Error Response Handling">
 <link href="#rfc.section.3" rel="Chapter" title="3 Authentication and Authorization">
 <link href="#rfc.section.3.1" rel="Chapter" title="3.1 Use of Tokens as Authorizations">
@@ -406,7 +407,7 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.34.0 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.17.1 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Backman, A., Ed., Jones, M., Ed., Scurtescu, M., Ansari, M., and A. Nadalin" />
@@ -516,7 +517,9 @@
 </li>
 </ul><li>2.5.   <a href="#rfc.section.2.5">Poll Response</a>
 </li>
-<li>2.6.   <a href="#rfc.section.2.6">Error Response Handling</a>
+<ul><li>2.5.1.   <a href="#rfc.section.2.5.1">Poll Error Response</a>
+</li>
+</ul><li>2.6.   <a href="#rfc.section.2.6">Error Response Handling</a>
 </li>
 </ul><li>3.   <a href="#rfc.section.3">Authentication and Authorization</a>
 </li>
@@ -741,7 +744,7 @@ Content-Type: application/json
 <h1 id="rfc.section.2.5">
 <a href="#rfc.section.2.5">2.5.</a> <a href="#pollGetAck" id="pollGetAck">Poll Response</a>
 </h1>
-<p id="rfc.section.2.5.p.1">In response to a poll request, the service provider MAY respond immediately if SETs are available to be delivered.  If no SETs are available at the time of the request, the SET Transmitter SHALL delay responding until a SET is available or the timeout interval has elapsed unless the poll request parameter <samp>returnImmediately</samp> is <samp>true</samp>.</p>
+<p id="rfc.section.2.5.p.1">In response to a valid poll request, the service provider MAY respond immediately if SETs are available to be delivered.  If no SETs are available at the time of the request, the SET Transmitter SHALL delay responding until a SET is available or the timeout interval has elapsed unless the poll request parameter <samp>returnImmediately</samp> is <samp>true</samp>.</p>
 <p id="rfc.section.2.5.p.2">As described in <a href="#pollResp" class="xref">Section 2.3</a>, a JSON document is returned containing a number of members including <samp>sets</samp>, which SHALL contain zero or more SETs.</p>
 <div id="rfc.figure.6"></div>
 <div id="pollResponse"></div>
@@ -787,6 +790,14 @@ Content-Type: application/json
 }</pre>
 <p class="figure">Figure 7: Example No SETs Poll Response</p>
 <p id="rfc.section.2.5.p.4">Upon receiving the JSON document (e.g., as shown in <a href="#pollResponse" class="xref">Figure 6</a>), the SET Recipient parses and verifies the received SETs and notifies the SET Transmitter via the next poll request to the SET Transmitter, as described in <a href="#pollAck" class="xref">Section 2.4.3</a> or <a href="#pollAckErr" class="xref">Section 2.4.4</a>.</p>
+<h1 id="rfc.section.2.5.1">
+<a href="#rfc.section.2.5.1">2.5.1.</a> Poll Error Response</h1>
+<p id="rfc.section.2.5.1.p.1">In the event of a general HTTP error condition in the context of processing a poll request, the service provider SHOULD respond with an appropriate HTTP Response Status Code as defined in Section 6 of <a href="#RFC7231" class="xref">[RFC7231]</a>.</p>
+<p id="rfc.section.2.5.1.p.2">Service providers MAY respond to any invalid poll request with an HTTP Response Status Code of 400 (Bad Request) even when a more specific code might apply, for example if the service provider deemed that a more specific code presented an information disclosure risk. When no more specific code might apply, the service provider SHALL respond to an invalid poll request with an HTTP Status Code of 400.</p>
+<p id="rfc.section.2.5.1.p.3">The response body for responses to invalid poll requests is left undefined.</p>
+<p>The following is a non-normative example of a response to an invalid poll request: </p>
+<pre>HTTP/1.1 400 Bad Request</pre>
+<p class="figure">Example Poll Error Response</p>
 <h1 id="rfc.section.2.6">
 <a href="#rfc.section.2.6">2.6.</a> <a href="#errorResponse" id="errorResponse">Error Response Handling</a>
 </h1>

--- a/draft-ietf-secevent-http-poll.txt
+++ b/draft-ietf-secevent-http-poll.txt
@@ -81,19 +81,20 @@ Table of Contents
        2.4.3.  Poll with Acknowledgement . . . . . . . . . . . . . .   8
        2.4.4.  Poll with Acknowledgement and Errors  . . . . . . . .   9
      2.5.  Poll Response . . . . . . . . . . . . . . . . . . . . . .   9
+       2.5.1.  Poll Error Response . . . . . . . . . . . . . . . . .  11
      2.6.  Error Response Handling . . . . . . . . . . . . . . . . .  11
    3.  Authentication and Authorization  . . . . . . . . . . . . . .  12
      3.1.  Use of Tokens as Authorizations . . . . . . . . . . . . .  12
-   4.  Security Considerations . . . . . . . . . . . . . . . . . . .  12
+   4.  Security Considerations . . . . . . . . . . . . . . . . . . .  13
      4.1.  Authentication Using Signed SETs  . . . . . . . . . . . .  13
      4.2.  HTTP Considerations . . . . . . . . . . . . . . . . . . .  13
      4.3.  Confidentiality of SETs . . . . . . . . . . . . . . . . .  13
-     4.4.  Access Token Considerations . . . . . . . . . . . . . . .  13
-       4.4.1.  Bearer Token Considerations . . . . . . . . . . . . .  13
+     4.4.  Access Token Considerations . . . . . . . . . . . . . . .  14
+       4.4.1.  Bearer Token Considerations . . . . . . . . . . . . .  14
    5.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .  14
-   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
-   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  14
-     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  14
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  15
+   7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  15
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  15
      7.2.  Informative References  . . . . . . . . . . . . . . . . .  16
    Appendix A.  Acknowledgments  . . . . . . . . . . . . . . . . . .  17
    Appendix B.  Change Log . . . . . . . . . . . . . . . . . . . . .  17
@@ -105,7 +106,6 @@ Table of Contents
    (SETs) [RFC8417] can be transmitted to an intended SET Recipient
    using HTTP [RFC7231] over TLS.  The specification defines a method to
    poll for SETs using HTTP POST.
-
 
 
 
@@ -480,7 +480,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 2.5.  Poll Response
 
-   In response to a poll request, the service provider MAY respond
+   In response to a valid poll request, the service provider MAY respond
    immediately if SETs are available to be delivered.  If no SETs are
    available at the time of the request, the SET Transmitter SHALL delay
    responding until a SET is available or the timeout interval has
@@ -580,12 +580,44 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
    SET Transmitter via the next poll request to the SET Transmitter, as
    described in Section 2.4.3 or Section 2.4.4.
 
+2.5.1.  Poll Error Response
+
+   In the event of a general HTTP error condition in the context of
+   processing a poll request, the service provider SHOULD respond with
+   an appropriate HTTP Response Status Code as defined in Section 6 of
+   [RFC7231].
+
+   Service providers MAY respond to any invalid poll request with an
+   HTTP Response Status Code of 400 (Bad Request) even when a more
+   specific code might apply, for example if the service provider deemed
+   that a more specific code presented an information disclosure risk.
+   When no more specific code might apply, the service provider SHALL
+   respond to an invalid poll request with an HTTP Status Code of 400.
+
+   The response body for responses to invalid poll requests is left
+   undefined.
+
+   The following is a non-normative example of a response to an invalid
+   poll request:
+
+   HTTP/1.1 400 Bad Request
+
+                        Example Poll Error Response
+
 2.6.  Error Response Handling
 
    If a SET is invalid, error codes from the IANA "Security Event Token
    Delivery Error Codes" registry established by
    [I-D.ietf-secevent-http-push] are used in error responses.  As
    described in Section 2.3 of [I-D.ietf-secevent-http-push], an error
+
+
+
+Backman, et al.            Expires May 4, 2020                 [Page 11]
+
+Internet-Draft        draft-ietf-secevent-http-poll        November 2019
+
+
    response is a JSON object providing details about the error that
    includes the following name/value pairs:
 
@@ -608,15 +640,6 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
    selection in the case when the SET Recipient can provide error
    messages in multiple languages is out of scope for this
    specification.
-
-
-
-
-
-Backman, et al.            Expires May 4, 2020                 [Page 11]
-
-Internet-Draft        draft-ietf-secevent-http-poll        November 2019
-
 
 3.  Authentication and Authorization
 
@@ -643,6 +666,14 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
    authorized scopes (see Section 3.3 of [RFC6749]), and the security
    subject(s) that SHOULD be mapped from the authorization when
    considering local access control rules.  Section 6 of the OAuth
+
+
+
+Backman, et al.            Expires May 4, 2020                 [Page 12]
+
+Internet-Draft        draft-ietf-secevent-http-poll        November 2019
+
+
    Assertion Framework specification [RFC7521] documents common
    scenarios for authorization including:
 
@@ -662,17 +693,6 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
    specifications.
 
 4.  Security Considerations
-
-
-
-
-
-
-
-Backman, et al.            Expires May 4, 2020                 [Page 12]
-
-Internet-Draft        draft-ietf-secevent-http-poll        November 2019
-
 
 4.1.  Authentication Using Signed SETs
 
@@ -702,6 +722,14 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
    transport-layer security mechanism such as TLS, or both.  If an Event
    delivery endpoint supports TLS, it MUST support at least TLS version
    1.2 [RFC5246] and SHOULD support the newest version of TLS that meets
+
+
+
+Backman, et al.            Expires May 4, 2020                 [Page 13]
+
+Internet-Draft        draft-ietf-secevent-http-poll        November 2019
+
+
    its security requirements.  When using TLS, the client MUST perform a
    TLS/SSL server certificate check, per [RFC6125].  Implementation
    security considerations for TLS can be found in "Recommendations for
@@ -722,14 +750,6 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
    directly or indirectly (e.g., by checking with a validation service)
    by the service provider.  By expiring tokens, clients are forced to
    obtain a new token (which usually involves re-authentication) for
-
-
-
-Backman, et al.            Expires May 4, 2020                 [Page 13]
-
-Internet-Draft        draft-ietf-secevent-http-poll        November 2019
-
-
    continued authorized access.  For example, in OAuth 2.0, a client MAY
    use an OAuth refresh token to obtain a new bearer token after
    authenticating to an authorization server, per Section 6 of
@@ -757,6 +777,15 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
    When sharing personally identifiable information or information that
    is otherwise considered confidential to affected users, SET
+
+
+
+
+Backman, et al.            Expires May 4, 2020                 [Page 14]
+
+Internet-Draft        draft-ietf-secevent-http-poll        November 2019
+
+
    Transmitters and Recipients MUST have the appropriate legal
    agreements and user consent or terms of service in place.
 
@@ -773,18 +802,6 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 7.  References
 
 7.1.  Normative References
-
-
-
-
-
-
-
-
-Backman, et al.            Expires May 4, 2020                 [Page 14]
-
-Internet-Draft        draft-ietf-secevent-http-poll        November 2019
-
 
    [I-D.ietf-secevent-http-push]
               Backman, A., Jones, M., Scurtescu, M., Ansari, M., and A.
@@ -814,6 +831,17 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
               Security (TLS)", RFC 6125, DOI 10.17487/RFC6125, March
               2011, <https://www.rfc-editor.org/info/rfc6125>.
 
+
+
+
+
+
+
+Backman, et al.            Expires May 4, 2020                 [Page 15]
+
+Internet-Draft        draft-ietf-secevent-http-poll        November 2019
+
+
    [RFC7231]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
               Protocol (HTTP/1.1): Semantics and Content", RFC 7231,
               DOI 10.17487/RFC7231, June 2014,
@@ -830,17 +858,6 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
    [RFC7519]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web Token
               (JWT)", RFC 7519, DOI 10.17487/RFC7519, May 2015,
               <https://www.rfc-editor.org/info/rfc7519>.
-
-
-
-
-
-
-
-Backman, et al.            Expires May 4, 2020                 [Page 15]
-
-Internet-Draft        draft-ietf-secevent-http-poll        November 2019
-
 
    [RFC7525]  Sheffer, Y., Holz, R., and P. Saint-Andre,
               "Recommendations for Secure Use of Transport Layer
@@ -874,6 +891,13 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
               DOI 10.17487/RFC6202, April 2011,
               <https://www.rfc-editor.org/info/rfc6202>.
 
+
+
+Backman, et al.            Expires May 4, 2020                 [Page 16]
+
+Internet-Draft        draft-ietf-secevent-http-poll        November 2019
+
+
    [RFC6749]  Hardt, D., Ed., "The OAuth 2.0 Authorization Framework",
               RFC 6749, DOI 10.17487/RFC6749, October 2012,
               <https://www.rfc-editor.org/info/rfc6749>.
@@ -887,16 +911,6 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
               Protocol (HTTP/1.1): Message Syntax and Routing",
               RFC 7230, DOI 10.17487/RFC7230, June 2014,
               <https://www.rfc-editor.org/info/rfc7230>.
-
-
-
-
-
-
-Backman, et al.            Expires May 4, 2020                 [Page 16]
-
-Internet-Draft        draft-ietf-secevent-http-poll        November 2019
-
 
    [RFC7235]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
               Protocol (HTTP/1.1): Authentication", RFC 7235,
@@ -932,6 +946,14 @@ Appendix B.  Change Log
    Draft 00 - AB - Based on draft-ietf-secevent-delivery-02 with the
    following additions:
 
+
+
+
+Backman, et al.            Expires May 4, 2020                 [Page 17]
+
+Internet-Draft        draft-ietf-secevent-http-poll        November 2019
+
+
    o  Renamed to "Poll-Based SET Token Delivery Using HTTP"
 
    o  Removed references to the HTTP Push delivery method.
@@ -945,14 +967,6 @@ Appendix B.  Change Log
       the already defined term SET Recipient rather than SET Receiver.
 
    o  Applied editorial and minor normative corrections.
-
-
-
-
-Backman, et al.            Expires May 4, 2020                 [Page 17]
-
-Internet-Draft        draft-ietf-secevent-http-poll        November 2019
-
 
    o  Updated Marius' contact information.
 
@@ -988,6 +1002,14 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
    Draft 04 - AB + mbj
 
+
+
+
+Backman, et al.            Expires May 4, 2020                 [Page 18]
+
+Internet-Draft        draft-ietf-secevent-http-poll        November 2019
+
+
    o  Referenced SET Transmitter definition in http-push.
 
    o  Removed incorrect normative text regarding SET construction.
@@ -1001,14 +1023,6 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
       aligning with http-push.
 
    o  Stated that bearer tokens SHOULD have a limited lifetime.
-
-
-
-
-Backman, et al.            Expires May 4, 2020                 [Page 18]
-
-Internet-Draft        draft-ietf-secevent-http-poll        November 2019
-
 
    o  Minor editorial fixes.
 
@@ -1043,20 +1057,6 @@ Authors' Addresses
    Microsoft
 
    Email: tonynad@microsoft.com
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/draft-ietf-secevent-http-poll.txt
+++ b/draft-ietf-secevent-http-poll.txt
@@ -5,14 +5,14 @@
 Network Working Group                                    A. Backman, Ed.
 Internet-Draft                                                    Amazon
 Intended status: Standards Track                           M. Jones, Ed.
-Expires: May 4, 2020                                           Microsoft
+Expires: May 9, 2020                                           Microsoft
                                                             M. Scurtescu
                                                                 Coinbase
                                                                M. Ansari
                                                                    Cisco
                                                               A. Nadalin
                                                                Microsoft
-                                                        November 1, 2019
+                                                        November 6, 2019
 
 
        Poll-Based Security Event Token (SET) Delivery Using HTTP
@@ -41,7 +41,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on May 4, 2020.
+   This Internet-Draft will expire on May 9, 2020.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Backman, et al.            Expires May 4, 2020                  [Page 1]
+Backman, et al.            Expires May 9, 2020                  [Page 1]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Backman, et al.            Expires May 4, 2020                  [Page 2]
+Backman, et al.            Expires May 9, 2020                  [Page 2]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -165,7 +165,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                  [Page 3]
+Backman, et al.            Expires May 9, 2020                  [Page 3]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -221,7 +221,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                  [Page 4]
+Backman, et al.            Expires May 9, 2020                  [Page 4]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -277,7 +277,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                  [Page 5]
+Backman, et al.            Expires May 9, 2020                  [Page 5]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -333,7 +333,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                  [Page 6]
+Backman, et al.            Expires May 9, 2020                  [Page 6]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -389,7 +389,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                  [Page 7]
+Backman, et al.            Expires May 9, 2020                  [Page 7]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -445,7 +445,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                  [Page 8]
+Backman, et al.            Expires May 9, 2020                  [Page 8]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -501,7 +501,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                  [Page 9]
+Backman, et al.            Expires May 9, 2020                  [Page 9]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -557,7 +557,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                 [Page 10]
+Backman, et al.            Expires May 9, 2020                 [Page 10]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -613,7 +613,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                 [Page 11]
+Backman, et al.            Expires May 9, 2020                 [Page 11]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -669,7 +669,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                 [Page 12]
+Backman, et al.            Expires May 9, 2020                 [Page 12]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -725,7 +725,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                 [Page 13]
+Backman, et al.            Expires May 9, 2020                 [Page 13]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -781,7 +781,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                 [Page 14]
+Backman, et al.            Expires May 9, 2020                 [Page 14]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -837,7 +837,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                 [Page 15]
+Backman, et al.            Expires May 9, 2020                 [Page 15]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -893,7 +893,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                 [Page 16]
+Backman, et al.            Expires May 9, 2020                 [Page 16]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -949,7 +949,7 @@ Appendix B.  Change Log
 
 
 
-Backman, et al.            Expires May 4, 2020                 [Page 17]
+Backman, et al.            Expires May 9, 2020                 [Page 17]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -1005,7 +1005,7 @@ Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
 
 
-Backman, et al.            Expires May 4, 2020                 [Page 18]
+Backman, et al.            Expires May 9, 2020                 [Page 18]
 
 Internet-Draft        draft-ietf-secevent-http-poll        November 2019
 
@@ -1061,4 +1061,4 @@ Authors' Addresses
 
 
 
-Backman, et al.            Expires May 4, 2020                 [Page 19]
+Backman, et al.            Expires May 9, 2020                 [Page 19]

--- a/draft-ietf-secevent-http-poll.xml
+++ b/draft-ietf-secevent-http-poll.xml
@@ -447,7 +447,7 @@ Content-Type: application/json
       <section anchor="pollGetAck"
 	       title="Poll Response">
 
-	<t>In response to a poll request, the service provider MAY
+	<t>In response to a valid poll request, the service provider MAY
 	respond immediately if SETs are available to be delivered.
 	If no SETs are available at the time of the request, the
 	SET Transmitter SHALL delay responding until a SET is
@@ -514,6 +514,27 @@ Content-Type: application/json
 	via the next poll request to the SET Transmitter, as described in
 	<xref target="pollAck"/> or <xref target="pollAckErr"/>.</t>
 	
+        <section title="Poll Error Response">
+            <t>In the event of a general HTTP error condition in the context of
+                processing a poll request, the service provider SHOULD respond with
+                an appropriate HTTP Response Status Code as defined in Section 6 of
+                <xref target="RFC7231" />.</t>
+
+            <t>Service providers MAY respond to any invalid poll request with an HTTP Response
+                Status Code of 400 (Bad Request) even when a more specific code might apply, for
+                example if the service provider deemed that a more specific code presented an
+                information disclosure risk. When no more specific code might apply, the service
+                provider SHALL respond to an invalid poll request with an HTTP Status Code of 400.</t>
+
+            <t>The response body for responses to invalid poll requests is left undefined.</t>
+
+            <figure title="Example Poll Error Response">
+                <preamble>
+                    The following is a non-normative example of a response to an invalid poll request:
+                </preamble>
+                <artwork>HTTP/1.1 400 Bad Request</artwork>
+            </figure>
+        </section>
       </section>
 
       <section anchor="errorResponse" title="Error Response Handling">

--- a/draft-ietf-secevent-http-poll.xml
+++ b/draft-ietf-secevent-http-poll.xml
@@ -56,7 +56,7 @@
       </address>
     </author>
 
-    <date year="2019" month="November" day="1" />
+    <date year="2019" month="November" day="6" />
 
     <keyword>Internet-Draft</keyword>
 


### PR DESCRIPTION
Added a section defining how a service provider should respond to invalid poll requests. I refrained from defining a new list of error codes, opting instead for HTTP status codes. I didn't see any value in creating a new list, and lots of opportunity for confusion between it and the existing SET Error Codes.