### PR TITLE
Addressing comments from AD Ben Kaduk

### DIFF
--- a/draft-ietf-secevent-http-poll.html
+++ b/draft-ietf-secevent-http-poll.html
@@ -406,14 +406,14 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.39.0 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.35.0 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Backman, A., Ed., Jones, M., Ed., Scurtescu, M., Ansari, M., and A. Nadalin" />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-secevent-http-poll-08" />
-  <meta name="dct.issued" scheme="ISO8601" content="2020-02-07" />
-  <meta name="dct.abstract" content="This specification defines how a series of Security Event Tokens (SETs) may be delivered to an intended recipient using HTTP POST over TLS initiated as a poll by the recipient. The specification also defines how delivery can be assured, subject to the SET Recipient's need for assurance.   " />
-  <meta name="description" content="This specification defines how a series of Security Event Tokens (SETs) may be delivered to an intended recipient using HTTP POST over TLS initiated as a poll by the recipient. The specification also defines how delivery can be assured, subject to the SET Recipient's need for assurance.   " />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-secevent-http-poll-09" />
+  <meta name="dct.issued" scheme="ISO8601" content="2020-04-27" />
+  <meta name="dct.abstract" content="This specification defines how a series of Security Event Tokens (SETs) may be delivered to an intended recipient using HTTP POST over TLS initiated as a poll by the recipient. The specification also defines how delivery can be assured, subject to the SET Recipient's need for assurance.  " />
+  <meta name="description" content="This specification defines how a series of Security Event Tokens (SETs) may be delivered to an intended recipient using HTTP POST over TLS initiated as a poll by the recipient. The specification also defines how delivery can be assured, subject to the SET Recipient's need for assurance.  " />
 
 </head>
 
@@ -435,7 +435,7 @@
 <td class="right">M. Jones, Ed.</td>
 </tr>
 <tr>
-<td class="left">Expires: August 10, 2020</td>
+<td class="left">Expires: October 29, 2020</td>
 <td class="right">Microsoft</td>
 </tr>
 <tr>
@@ -464,7 +464,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">February 7, 2020</td>
+<td class="right">April 27, 2020</td>
 </tr>
 
     	
@@ -472,7 +472,7 @@
   </table>
 
   <p class="title">Poll-Based Security Event Token (SET) Delivery Using HTTP<br />
-  <span class="filename">draft-ietf-secevent-http-poll-08</span></p>
+  <span class="filename">draft-ietf-secevent-http-poll-09</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This specification defines how a series of Security Event Tokens (SETs) may be delivered to an intended recipient using HTTP POST over TLS initiated as a poll by the recipient. The specification also defines how delivery can be assured, subject to the SET Recipient's need for assurance.  </p>
@@ -480,7 +480,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on August 10, 2020.</p>
+<p>This Internet-Draft will expire on October 29, 2020.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2020 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -830,7 +830,7 @@ Content-Type: application/json
 <p id="rfc.section.4.2.p.2">As stated in Section 2.7.1 of <a href="#RFC7230" class="xref">[RFC7230]</a>, an HTTP requestor MUST NOT generate the <samp>userinfo</samp> (i.e., username and password) component (and its "@" delimiter) when an "http" URI reference is generated with a message, as they are now disallowed in HTTP.</p>
 <h1 id="rfc.section.4.3">
 <a href="#rfc.section.4.3">4.3.</a> Confidentiality of SETs</h1>
-<p id="rfc.section.4.3.p.1">SETs may contain sensitive information that is considered Personally Identifiable Information (PII).  In such cases, SET Transmitters and SET Recipients MUST protect the confidentiality of the SET contents by encrypting the SET as described in JWE <a href="#RFC7516" class="xref">[RFC7516]</a>, using a transport-layer security mechanism such as TLS, or both. If an Event delivery endpoint supports TLS, it MUST support at least TLS version 1.2 <a href="#RFC5246" class="xref">[RFC5246]</a> and SHOULD support the newest version of TLS that meets its security requirements, which as of the time of this publication is TLS 1.3 <a href="#RFC8446" class="xref">[RFC8446]</a>.  When using TLS, the client MUST perform a TLS/SSL server certificate check using DNS-ID <a href="#RFC6125" class="xref">[RFC6125]</a>.  Implementation security considerations for TLS can be found in "Recommendations for Secure Use of TLS and DTLS" <a href="#RFC7525" class="xref">[RFC7525]</a>.  </p>
+<p id="rfc.section.4.3.p.1">SETs may contain sensitive information that is considered Personally Identifiable Information (PII).  In such cases, SET Transmitters and SET Recipients MUST protect the confidentiality of the SET contents by encrypting the SET as described in JWE <a href="#RFC7516" class="xref">[RFC7516]</a>, using a transport-layer security mechanism such as TLS, or both. If an Event delivery endpoint supports TLS, it MUST support at least TLS version 1.2 <a href="#RFC5246" class="xref">[RFC5246]</a> and SHOULD support the newest version of TLS that meets its security requirements, which as of the time of this publication is TLS 1.3 <a href="#RFC8446" class="xref">[RFC8446]</a>.  When using TLS, the client MUST perform a TLS/SSL server certificate check using DNS-ID <a href="#RFC6125" class="xref">[RFC6125]</a>.  How a SET Recipient determines the expected service identity to match the SET Transmitter's server certificate against is out of scope for this document.  Implementation security considerations for TLS can be found in "Recommendations for Secure Use of TLS and DTLS" <a href="#RFC7525" class="xref">[RFC7525]</a>.  </p>
 <h1 id="rfc.section.4.4">
 <a href="#rfc.section.4.4">4.4.</a> Access Token Considerations</h1>
 <p id="rfc.section.4.4.p.1">If HTTP Authentication is performed using OAuth access tokens <a href="#RFC6749" class="xref">[RFC6749]</a>, implementers MUST take into account the threats and countermeasures documented in Section 8 of <a href="#RFC7521" class="xref">[RFC7521]</a>.</p>
@@ -1041,6 +1041,13 @@ Content-Type: application/json
 <p id="rfc.section.B.p.10">Draft 08 - mbj + AB </p>
 
 <ul><li>Corrected editorial nits.  </li></ul>
+
+<p> </p>
+<p id="rfc.section.B.p.11">Draft 09 - AB </p>
+
+<ul><li>Addressed area director review comments by Benamin Kaduk: <ul><li>Added text clarifying that determining the SET Recipient's service identity is out of scope.</li></ul>
+<p> </p>
+</li></ul>
 
 <p> </p>
 <h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>

--- a/draft-ietf-secevent-http-poll.txt
+++ b/draft-ietf-secevent-http-poll.txt
@@ -5,18 +5,18 @@
 Security Events Working Group                            A. Backman, Ed.
 Internet-Draft                                                    Amazon
 Intended status: Standards Track                           M. Jones, Ed.
-Expires: August 10, 2020                                       Microsoft
+Expires: October 29, 2020                                      Microsoft
                                                             M. Scurtescu
                                                                 Coinbase
                                                                M. Ansari
                                                                    Cisco
                                                               A. Nadalin
                                                                Microsoft
-                                                        February 7, 2020
+                                                          April 27, 2020
 
 
        Poll-Based Security Event Token (SET) Delivery Using HTTP
-                    draft-ietf-secevent-http-poll-08
+                    draft-ietf-secevent-http-poll-09
 
 Abstract
 
@@ -41,7 +41,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on August 10, 2020.
+   This Internet-Draft will expire on October 29, 2020.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Backman, et al.          Expires August 10, 2020                [Page 1]
+Backman, et al.         Expires October 29, 2020                [Page 1]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
    (https://trustee.ietf.org/license-info) in effect on the date of
@@ -93,7 +93,7 @@ Table of Contents
    5.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .  14
    6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
    7.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  14
-     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  14
+     7.1.  Normative References  . . . . . . . . . . . . . . . . . .  15
      7.2.  Informative References  . . . . . . . . . . . . . . . . .  16
    Appendix A.  Acknowledgments  . . . . . . . . . . . . . . . . . .  17
    Appendix B.  Change Log . . . . . . . . . . . . . . . . . . . . .  17
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Backman, et al.          Expires August 10, 2020                [Page 2]
+Backman, et al.         Expires October 29, 2020                [Page 2]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
    A mechanism for exchanging configuration metadata such as endpoint
@@ -165,9 +165,9 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 
 
-Backman, et al.          Expires August 10, 2020                [Page 3]
+Backman, et al.         Expires October 29, 2020                [Page 3]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
 2.1.  Polling Delivery using HTTP
@@ -221,9 +221,9 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 
 
-Backman, et al.          Expires August 10, 2020                [Page 4]
+Backman, et al.         Expires October 29, 2020                [Page 4]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
          Recipients that would like to perform an acknowledge only
@@ -277,9 +277,9 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 
 
-Backman, et al.          Expires August 10, 2020                [Page 5]
+Backman, et al.         Expires October 29, 2020                [Page 5]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
       the meaning being the same as including it with the boolean value
@@ -333,9 +333,9 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 
 
-Backman, et al.          Expires August 10, 2020                [Page 6]
+Backman, et al.         Expires October 29, 2020                [Page 6]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
 2.4.1.  Poll Only Request
@@ -389,9 +389,9 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 
 
-Backman, et al.          Expires August 10, 2020                [Page 7]
+Backman, et al.         Expires October 29, 2020                [Page 7]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
    The following is a non-normative example poll request with
@@ -445,9 +445,9 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 
 
-Backman, et al.          Expires August 10, 2020                [Page 8]
+Backman, et al.         Expires October 29, 2020                [Page 8]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
 2.4.4.  Poll with Acknowledgement and Errors
@@ -501,9 +501,9 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 
 
-Backman, et al.          Expires August 10, 2020                [Page 9]
+Backman, et al.         Expires October 29, 2020                [Page 9]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
    The following is a non-normative example response to the request
@@ -557,9 +557,9 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 
 
-Backman, et al.          Expires August 10, 2020               [Page 10]
+Backman, et al.         Expires October 29, 2020               [Page 10]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
    The following is a non-normative example response to the request
@@ -613,9 +613,9 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 
 
-Backman, et al.          Expires August 10, 2020               [Page 11]
+Backman, et al.         Expires October 29, 2020               [Page 11]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
    described in Section 2.3 of [I-D.ietf-secevent-http-push], an error
@@ -669,9 +669,9 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 
 
-Backman, et al.          Expires August 10, 2020               [Page 12]
+Backman, et al.         Expires October 29, 2020               [Page 12]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
 4.1.  Authentication Using Signed SETs
@@ -704,9 +704,11 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
    1.2 [RFC5246] and SHOULD support the newest version of TLS that meets
    its security requirements, which as of the time of this publication
    is TLS 1.3 [RFC8446].  When using TLS, the client MUST perform a TLS/
-   SSL server certificate check using DNS-ID [RFC6125].  Implementation
-   security considerations for TLS can be found in "Recommendations for
-   Secure Use of TLS and DTLS" [RFC7525].
+   SSL server certificate check using DNS-ID [RFC6125].  How a SET
+   Recipient determines the expected service identity to match the SET
+   Transmitter's server certificate against is out of scope for this
+   document.  Implementation security considerations for TLS can be
+   found in "Recommendations for Secure Use of TLS and DTLS" [RFC7525].
 
 4.4.  Access Token Considerations
 
@@ -719,17 +721,18 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
    Due to the possibility of interception, Bearer tokens [RFC6750] MUST
    be exchanged using TLS.
 
+
+
+
+
+Backman, et al.         Expires October 29, 2020               [Page 13]
+
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
+
+
    Bearer tokens SHOULD have a limited lifetime that can be determined
    directly or indirectly (e.g., by checking with a validation service)
    by the service provider.  By expiring tokens, clients are forced to
-
-
-
-Backman, et al.          Expires August 10, 2020               [Page 13]
-
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
-
-
    obtain a new token (which usually involves re-authentication) for
    continued authorized access.  For example, in OAuth 2.0, a client MAY
    use an OAuth refresh token to obtain a new bearer token after
@@ -772,19 +775,18 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 7.  References
 
-7.1.  Normative References
 
 
 
 
 
 
-
-
-Backman, et al.          Expires August 10, 2020               [Page 14]
+Backman, et al.         Expires October 29, 2020               [Page 14]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
+
+7.1.  Normative References
 
    [I-D.ietf-secevent-http-push]
               Backman, A., Jones, M., Scurtescu, M., Ansari, M., and A.
@@ -835,11 +837,9 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 
 
-
-
-Backman, et al.          Expires August 10, 2020               [Page 15]
+Backman, et al.         Expires October 29, 2020               [Page 15]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
    [RFC7525]  Sheffer, Y., Holz, R., and P. Saint-Andre,
@@ -893,9 +893,9 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 
 
-Backman, et al.          Expires August 10, 2020               [Page 16]
+Backman, et al.         Expires October 29, 2020               [Page 16]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
    [RFC7235]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
@@ -949,9 +949,9 @@ Appendix B.  Change Log
 
 
 
-Backman, et al.          Expires August 10, 2020               [Page 17]
+Backman, et al.         Expires October 29, 2020               [Page 17]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
       [I-D.ietf-secevent-http-push], referencing, rather that
@@ -1005,9 +1005,9 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
 
 
 
-Backman, et al.          Expires August 10, 2020               [Page 18]
+Backman, et al.         Expires October 29, 2020               [Page 18]
 
-Internet-Draft        draft-ietf-secevent-http-poll        February 2020
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
 
 
    o  Added normative text defining how to respond to invalid poll
@@ -1026,6 +1026,13 @@ Internet-Draft        draft-ietf-secevent-http-poll        February 2020
    Draft 08 - mbj + AB
 
    o  Corrected editorial nits.
+
+   Draft 09 - AB
+
+   o  Addressed area director review comments by Benamin Kaduk:
+
+      *  Added text clarifying that determining the SET Recipient's
+         service identity is out of scope.
 
 Authors' Addresses
 
@@ -1048,6 +1055,17 @@ Authors' Addresses
    Email: marius.scurtescu@coinbase.com
 
 
+
+
+
+
+
+
+Backman, et al.         Expires October 29, 2020               [Page 19]
+
+Internet-Draft        draft-ietf-secevent-http-poll           April 2020
+
+
    Morteza Ansari
    Cisco
 
@@ -1061,4 +1079,42 @@ Authors' Addresses
 
 
 
-Backman, et al.          Expires August 10, 2020               [Page 19]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Backman, et al.         Expires October 29, 2020               [Page 20]

--- a/draft-ietf-secevent-http-poll.xml
+++ b/draft-ietf-secevent-http-poll.xml
@@ -11,7 +11,7 @@
 <?rfc inline="yes"?>
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
-<rfc category="std" docName="draft-ietf-secevent-http-poll-08"
+<rfc category="std" docName="draft-ietf-secevent-http-poll-09"
 	ipr="trust200902">
   <front>
     <title abbrev="draft-ietf-secevent-http-poll">
@@ -56,7 +56,7 @@
       </address>
     </author>
 
-    <date year="2020" month="February" day="7" />
+    <date year="2020" month="April" day="27" />
 
     <area>Security</area>
     <workgroup>Security Events Working Group</workgroup>
@@ -651,6 +651,8 @@ Content-Type: application/json
 	  which as of the time of this publication is TLS 1.3 <xref target="RFC8446"/>.
 	  When using TLS, the client MUST
 	  perform a TLS/SSL server certificate check using DNS-ID <xref target="RFC6125"/>.
+          How a SET Recipient determines the expected service identity to match the SET
+          Transmitter's server certificate against is out of scope for this document.
 	  Implementation security considerations for TLS can be found in
 	  "Recommendations for Secure Use of TLS and DTLS" <xref target="RFC7525"/>.
 	</t>
@@ -905,6 +907,17 @@ Content-Type: application/json
         <list style="symbols">
           <t>
             Corrected editorial nits.
+          </t>
+        </list>
+      </t>
+      <t>
+        Draft 09 - AB
+        <list style="symbols">
+          <t>
+            Addressed area director review comments by Benamin Kaduk:
+            <list style="symbols">
+              <t>Added text clarifying that determining the SET Recipient's service identity is out of scope.</t>
+            </list>
           </t>
         </list>
       </t>

--- a/draft-ietf-secevent-http-push.html
+++ b/draft-ietf-secevent-http-push.html
@@ -404,14 +404,14 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.39.0 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.35.0 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Backman, A., Ed., Jones, M., Ed., Scurtescu, M., Ansari, M., and A. Nadalin" />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-secevent-http-push-09" />
-  <meta name="dct.issued" scheme="ISO8601" content="2020-02-07" />
-  <meta name="dct.abstract" content="This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.   " />
-  <meta name="description" content="This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.   " />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-secevent-http-push-10" />
+  <meta name="dct.issued" scheme="ISO8601" content="2020-04-27" />
+  <meta name="dct.abstract" content="This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  " />
+  <meta name="description" content="This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  " />
 
 </head>
 
@@ -433,7 +433,7 @@
 <td class="right">M. Jones, Ed.</td>
 </tr>
 <tr>
-<td class="left">Expires: August 10, 2020</td>
+<td class="left">Expires: October 29, 2020</td>
 <td class="right">Microsoft</td>
 </tr>
 <tr>
@@ -462,7 +462,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">February 7, 2020</td>
+<td class="right">April 27, 2020</td>
 </tr>
 
     	
@@ -470,7 +470,7 @@
   </table>
 
   <p class="title">Push-Based Security Event Token (SET) Delivery Using HTTP<br />
-  <span class="filename">draft-ietf-secevent-http-push-09</span></p>
+  <span class="filename">draft-ietf-secevent-http-push-10</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This specification defines how a Security Event Token (SET) may be delivered to an intended recipient using HTTP POST.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  </p>
@@ -478,7 +478,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on August 10, 2020.</p>
+<p>This Internet-Draft will expire on October 29, 2020.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2020 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -561,7 +561,7 @@
 </ul>
 
 <p> </p>
-<p id="rfc.section.1.p.3">A mechanism for exchanging configuration metadata such as endpoint URLs and cryptographic keys between the transmitter and recipient is out of scope for this specification.  </p>
+<p id="rfc.section.1.p.3">A mechanism for exchanging configuration metadata such as endpoint URLs and cryptographic keys between the transmitter and recipient is out of scope for this specification. How SETs are defined and the process by which security events are identified for SET Recipients are specified in <a href="#RFC8417" class="xref">[RFC8417]</a>.  </p>
 <h1 id="rfc.section.1.1">
 <a href="#rfc.section.1.1">1.1.</a> <a href="#notat" id="notat">Notational Conventions</a>
 </h1>
@@ -744,7 +744,7 @@ Content-Type: application/json
 <p id="rfc.section.5.2.p.2">As stated in Section 2.7.1 of <a href="#RFC7230" class="xref">[RFC7230]</a>, an HTTP requestor MUST NOT generate the <samp>userinfo</samp> (i.e., username and password) component (and its "@" delimiter) when an "http" URI reference is generated with a message, as they are now disallowed in HTTP.</p>
 <h1 id="rfc.section.5.3">
 <a href="#rfc.section.5.3">5.3.</a> Confidentiality of SETs</h1>
-<p id="rfc.section.5.3.p.1">SETs may contain sensitive information that is considered Personally Identifiable Information (e.g., subject claims). In such cases, SET Transmitters and SET Recipients MUST protect the confidentiality of the SET contents by encrypting the SET as described in <a href="#RFC7516" class="xref">JWE</a>, using a transport-layer security mechanism such as TLS, or both. If an Event delivery endpoint supports TLS, it MUST support at least TLS version 1.2 <a href="#RFC5246" class="xref">[RFC5246]</a> and SHOULD support the newest version of TLS that meets its security requirements, which as of the time of this publication is TLS 1.3 <a href="#RFC8446" class="xref">[RFC8446]</a>.  When using TLS, the client MUST perform a TLS/SSL server certificate check using DNS-ID <a href="#RFC6125" class="xref">[RFC6125]</a>.  Implementation security considerations for TLS can be found in "Recommendations for Secure Use of TLS and DTLS" <a href="#RFC7525" class="xref">[RFC7525]</a>.</p>
+<p id="rfc.section.5.3.p.1">SETs may contain sensitive information that is considered Personally Identifiable Information (PII). In such cases, SET Transmitters and SET Recipients MUST protect the confidentiality of the SET contents by encrypting the SET as described in <a href="#RFC7516" class="xref">JWE</a>, using a transport-layer security mechanism such as TLS, or both. If an Event delivery endpoint supports TLS, it MUST support at least TLS version 1.2 <a href="#RFC5246" class="xref">[RFC5246]</a> and SHOULD support the newest version of TLS that meets its security requirements, which as of the time of this publication is TLS 1.3 <a href="#RFC8446" class="xref">[RFC8446]</a>.  When using TLS, the client MUST perform a TLS/SSL server certificate check using DNS-ID <a href="#RFC6125" class="xref">[RFC6125]</a>.  How a SET Transmitter determines the expected service identity to match the SET Recipient's server certificate against is out of scope for this document.  Implementation security considerations for TLS can be found in "Recommendations for Secure Use of TLS and DTLS" <a href="#RFC7525" class="xref">[RFC7525]</a>.</p>
 <h1 id="rfc.section.5.4">
 <a href="#rfc.section.5.4">5.4.</a> Denial of Service</h1>
 <p id="rfc.section.5.4.p.1">The SET Recipient may be vulnerable to a denial-of-service attack where a malicious party makes a high volume of requests containing invalid SETs, causing the endpoint to expend significant resources on cryptographic operations that are bound to fail. This may be mitigated by authenticating SET Transmitters with a mechanism with low runtime overhead, such as mutual TLS.  </p>
@@ -753,8 +753,9 @@ Content-Type: application/json
 <p id="rfc.section.5.5.p.1">At the time of receipt, the SET Recipient can rely upon transport layer mechanisms, HTTP authentication methods, and/or other context from the transmission request to authenticate the SET Transmitter and validate the authenticity of the SET.  However, this context is typically unavailable to systems that the SET Recipient forwards the SET onto, or to systems that retrieve the SET from storage.  If the SET Recipient requires the ability to validate SET authenticity outside of the context of the transmission request, then the SET Recipient SHOULD ensure that such SETs have been signed in accordance with <a href="#RFC7515" class="xref">[RFC7515]</a>.  </p>
 <h1 id="rfc.section.6">
 <a href="#rfc.section.6">6.</a> Privacy Considerations</h1>
-<p id="rfc.section.6.p.1">When sharing personally identifiable information or information that is otherwise considered confidential to affected users, SET Transmitters and Recipients MUST have the appropriate legal agreements and user consent or terms of service in place.  Furthermore, data that needs confidentiality protection MUST be encrypted, either via TLS or using JSON Web Encryption (JWE) <a href="#RFC7516" class="xref">[RFC7516]</a>, or both.  </p>
-<p id="rfc.section.6.p.2">In some cases, subject identifiers themselves may be considered sensitive information, such that their inclusion within a SET may be considered a violation of privacy.  SET Transmitters should consider the ramifications of sharing a particular subject identifier with a SET Recipient (e.g., whether doing so could enable correlation and/or de-anonymization of data) and choose appropriate subject identifiers for their use cases.  </p>
+<p id="rfc.section.6.p.1">SET Transmistters SHOULD attempt to deliver SETs that are targeted to the specific business and protocol needs of subscribers.  </p>
+<p id="rfc.section.6.p.2">When sharing personally identifiable information or information that is otherwise considered confidential to affected users, SET Transmitters and Recipients MUST have the appropriate legal agreements and user consent or terms of service in place.  Furthermore, data that needs confidentiality protection MUST be encrypted, either via TLS or using JSON Web Encryption (JWE) <a href="#RFC7516" class="xref">[RFC7516]</a>, or both.  </p>
+<p id="rfc.section.6.p.3">In some cases, subject identifiers themselves may be considered sensitive information, such that their inclusion within a SET may be considered a violation of privacy.  SET Transmitters should consider the ramifications of sharing a particular subject identifier with a SET Recipient (e.g., whether doing so could enable correlation and/or de-anonymization of data) and choose appropriate subject identifiers for their use cases.  </p>
 <h1 id="rfc.section.7">
 <a href="#rfc.section.7">7.</a> <a href="#IANA" id="IANA">IANA Considerations</a>
 </h1>
@@ -1098,6 +1099,18 @@ need for assurance.</pre>
 <p id="rfc.section.C.p.11">Draft 09 - mbj + AB </p>
 
 <ul><li>Corrected editorial nits.  </li></ul>
+
+<p> </p>
+<p id="rfc.section.C.p.12">Draft 10 - AB </p>
+
+<ul><li>Addressed area director review comments by Benamin Kaduk: <ul>
+<li>Added reference to 8417 as definition document for SETs.</li>
+<li>Added text clarifying that determining the SET Recipient's service identity is out of scope.  </li>
+<li>Added normative recommendation for transmitters to target SETs to specific business needs of subscribers.  </li>
+<li>Minor editorial corrections.</li>
+</ul>
+<p> </p>
+</li></ul>
 
 <p> </p>
 <h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>

--- a/draft-ietf-secevent-http-push.txt
+++ b/draft-ietf-secevent-http-push.txt
@@ -5,18 +5,18 @@
 Security Events Working Group                            A. Backman, Ed.
 Internet-Draft                                                    Amazon
 Intended status: Standards Track                           M. Jones, Ed.
-Expires: August 10, 2020                                       Microsoft
+Expires: October 29, 2020                                      Microsoft
                                                             M. Scurtescu
                                                                 Coinbase
                                                                M. Ansari
                                                                    Cisco
                                                               A. Nadalin
                                                                Microsoft
-                                                        February 7, 2020
+                                                          April 27, 2020
 
 
        Push-Based Security Event Token (SET) Delivery Using HTTP
-                    draft-ietf-secevent-http-push-09
+                    draft-ietf-secevent-http-push-10
 
 Abstract
 
@@ -41,7 +41,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on August 10, 2020.
+   This Internet-Draft will expire on October 29, 2020.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Backman, et al.          Expires August 10, 2020                [Page 1]
+Backman, et al.         Expires October 29, 2020                [Page 1]
 
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
 
 
    (https://trustee.ietf.org/license-info) in effect on the date of
@@ -75,13 +75,13 @@ Table of Contents
      2.1.  Transmitting a SET  . . . . . . . . . . . . . . . . . . .   5
      2.2.  Success Response  . . . . . . . . . . . . . . . . . . . .   5
      2.3.  Failure Response  . . . . . . . . . . . . . . . . . . . .   6
-     2.4.  Security Event Token Delivery Error Codes . . . . . . . .   7
+     2.4.  Security Event Token Delivery Error Codes . . . . . . . .   8
    3.  Authentication and Authorization  . . . . . . . . . . . . . .   8
    4.  Delivery Reliability  . . . . . . . . . . . . . . . . . . . .   9
    5.  Security Considerations . . . . . . . . . . . . . . . . . . .   9
      5.1.  Authentication Using Signed SETs  . . . . . . . . . . . .   9
      5.2.  HTTP Considerations . . . . . . . . . . . . . . . . . . .   9
-     5.3.  Confidentiality of SETs . . . . . . . . . . . . . . . . .   9
+     5.3.  Confidentiality of SETs . . . . . . . . . . . . . . . . .  10
      5.4.  Denial of Service . . . . . . . . . . . . . . . . . . . .  10
      5.5.  Authenticating Persisted SETs . . . . . . . . . . . . . .  10
    6.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .  10
@@ -95,7 +95,7 @@ Table of Contents
    Appendix A.  Other Streaming Specifications . . . . . . . . . . .  14
    Appendix B.  Acknowledgments  . . . . . . . . . . . . . . . . . .  16
    Appendix C.  Change Log . . . . . . . . . . . . . . . . . . . . .  16
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  20
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  21
 
 1.  Introduction and Overview
 
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Backman, et al.          Expires August 10, 2020                [Page 2]
+Backman, et al.         Expires October 29, 2020                [Page 2]
 
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
 
 
    o  The transmitter of the SET is capable of making outbound HTTP
@@ -124,7 +124,9 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
 
    A mechanism for exchanging configuration metadata such as endpoint
    URLs and cryptographic keys between the transmitter and recipient is
-   out of scope for this specification.
+   out of scope for this specification.  How SETs are defined and the
+   process by which security events are identified for SET Recipients
+   are specified in [RFC8417].
 
 1.1.  Notational Conventions
 
@@ -161,14 +163,14 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
    Upon receipt of a SET, the SET Recipient SHALL validate that all of
    the following are true:
 
-   o  The SET Recipient can parse the SET.
 
 
-
-Backman, et al.          Expires August 10, 2020                [Page 3]
+Backman, et al.         Expires October 29, 2020                [Page 3]
 
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
 
+
+   o  The SET Recipient can parse the SET.
 
    o  The SET is authentic (i.e., it was issued by the issuer specified
       within the SET, and if signed, was signed by a key belonging to
@@ -215,16 +217,17 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
    previous transmissions timed out or indicated potentially recoverable
    error (such as server unavailability that may be transient).  In all
    other cases, the SET Transmitter SHOULD NOT re-transmit a SET.  The
+
+
+
+
+Backman, et al.         Expires October 29, 2020                [Page 4]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    SET Transmitter SHOULD delay retransmission for an appropriate amount
    of time to avoid overwhelming the SET Recipient (see Section 4).
-
-
-
-
-Backman, et al.          Expires August 10, 2020                [Page 4]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
 2.1.  Transmitting a SET
 
@@ -270,17 +273,17 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
 
    If the SET is determined to be valid, the SET Recipient SHALL
    acknowledge successful transmission by responding with HTTP Response
+
+
+
+
+Backman, et al.         Expires October 29, 2020                [Page 5]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    Status Code 202 (Accepted) (see Section 6.3.3 of [RFC7231]).  The
    body of the response MUST be empty.
-
-
-
-
-
-Backman, et al.          Expires August 10, 2020                [Page 5]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
    The following is a non-normative example of a successful receipt of a
    SET.
@@ -326,17 +329,17 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
    Section 5.3.5 of [RFC7231].  If the SET Transmitter did not send an
    "Accept-Language" header, or if the SET Recipient does not support
    any of the languages included in the header, the SET Recipient MUST
+
+
+
+
+Backman, et al.         Expires October 29, 2020                [Page 6]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    respond with messages that are understandable by an English-speaking
    person, as described in Section 4.5 of [RFC2277].
-
-
-
-
-
-Backman, et al.          Expires August 10, 2020                [Page 6]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
    The following is an example non-normative error response indicating
    that the key used to encrypt the SET has been revoked.
@@ -381,19 +384,21 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
 
              Figure 5: Example Error Response (access_denied)
 
+
+
+
+
+
+Backman, et al.         Expires October 29, 2020                [Page 7]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
 2.4.  Security Event Token Delivery Error Codes
 
    Security Event Token Delivery Error Codes are strings that identify a
    specific category of error that may occur when parsing or validating
    a SET.  Every Security Event Token Delivery Error Code MUST have a
-
-
-
-Backman, et al.          Expires August 10, 2020                [Page 7]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
-
    unique name registered in the IANA "Security Event Token Delivery
    Error Codes" registry established by Section 7.1.
 
@@ -436,19 +441,17 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
    Authorization for the eligibility to provide actionable SETs can be
    determined by using the identity of the SET Issuer, the identity of
    the SET Transmitter, perhaps using mutual TLS, or via other employed
+
+
+
+
+Backman, et al.         Expires October 29, 2020                [Page 8]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    authentication methods.  Because SETs are not commands, SET
    Recipients are free to ignore SETs that are not of interest.
-
-
-
-
-
-
-
-Backman, et al.          Expires August 10, 2020                [Page 8]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
 4.  Delivery Reliability
 
@@ -492,28 +495,33 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
    its "@" delimiter) when an "http" URI reference is generated with a
    message, as they are now disallowed in HTTP.
 
+
+
+
+
+
+
+Backman, et al.         Expires October 29, 2020                [Page 9]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
 5.3.  Confidentiality of SETs
 
    SETs may contain sensitive information that is considered Personally
-   Identifiable Information (e.g., subject claims).  In such cases, SET
-   Transmitters and SET Recipients MUST protect the confidentiality of
-   the SET contents by encrypting the SET as described in JWE [RFC7516],
-
-
-
-Backman, et al.          Expires August 10, 2020                [Page 9]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
-
-   using a transport-layer security mechanism such as TLS, or both.  If
-   an Event delivery endpoint supports TLS, it MUST support at least TLS
-   version 1.2 [RFC5246] and SHOULD support the newest version of TLS
-   that meets its security requirements, which as of the time of this
-   publication is TLS 1.3 [RFC8446].  When using TLS, the client MUST
-   perform a TLS/SSL server certificate check using DNS-ID [RFC6125].
-   Implementation security considerations for TLS can be found in
-   "Recommendations for Secure Use of TLS and DTLS" [RFC7525].
+   Identifiable Information (PII).  In such cases, SET Transmitters and
+   SET Recipients MUST protect the confidentiality of the SET contents
+   by encrypting the SET as described in JWE [RFC7516], using a
+   transport-layer security mechanism such as TLS, or both.  If an Event
+   delivery endpoint supports TLS, it MUST support at least TLS version
+   1.2 [RFC5246] and SHOULD support the newest version of TLS that meets
+   its security requirements, which as of the time of this publication
+   is TLS 1.3 [RFC8446].  When using TLS, the client MUST perform a TLS/
+   SSL server certificate check using DNS-ID [RFC6125].  How a SET
+   Transmitter determines the expected service identity to match the SET
+   Recipient's server certificate against is out of scope for this
+   document.  Implementation security considerations for TLS can be
+   found in "Recommendations for Secure Use of TLS and DTLS" [RFC7525].
 
 5.4.  Denial of Service
 
@@ -539,10 +547,21 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
 
 6.  Privacy Considerations
 
+   SET Transmistters SHOULD attempt to deliver SETs that are targeted to
+   the specific business and protocol needs of subscribers.
+
    When sharing personally identifiable information or information that
    is otherwise considered confidential to affected users, SET
    Transmitters and Recipients MUST have the appropriate legal
    agreements and user consent or terms of service in place.
+
+
+
+Backman, et al.         Expires October 29, 2020               [Page 10]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    Furthermore, data that needs confidentiality protection MUST be
    encrypted, either via TLS or using JSON Web Encryption (JWE)
    [RFC7516], or both.
@@ -554,13 +573,6 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
    SET Recipient (e.g., whether doing so could enable correlation and/or
    de-anonymization of data) and choose appropriate subject identifiers
    for their use cases.
-
-
-
-Backman, et al.          Expires August 10, 2020               [Page 10]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
 7.  IANA Considerations
 
@@ -599,24 +611,19 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
       information such as mailing address, email address, or phone
       number may also be provided.
 
+
+
+Backman, et al.         Expires October 29, 2020               [Page 11]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    Defining Document(s)
       A reference to the document or documents that define the Security
       Event Token Delivery Error Code.  The definition MUST specify the
       name and description of the error code and explain under what
       circumstances the error code may be used.  URIs that can be used
       to retrieve copies of each document at no cost SHOULD be included.
-
-
-
-
-
-
-
-
-Backman, et al.          Expires August 10, 2020               [Page 11]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
 7.1.2.  Initial Registry Contents
 
@@ -659,20 +666,17 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
               Languages", BCP 18, RFC 2277, DOI 10.17487/RFC2277,
               January 1998, <https://www.rfc-editor.org/info/rfc2277>.
 
+
+
+
+Backman, et al.         Expires October 29, 2020               [Page 12]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    [RFC2818]  Rescorla, E., "HTTP Over TLS", RFC 2818,
               DOI 10.17487/RFC2818, May 2000,
               <https://www.rfc-editor.org/info/rfc2818>.
-
-
-
-
-
-
-
-Backman, et al.          Expires August 10, 2020               [Page 12]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
    [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
               (TLS) Protocol Version 1.2", RFC 5246,
@@ -719,16 +723,16 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
               RFC 8126, DOI 10.17487/RFC8126, June 2017,
               <https://www.rfc-editor.org/info/rfc8126>.
 
+
+
+Backman, et al.         Expires October 29, 2020               [Page 13]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
-
-
-
-Backman, et al.          Expires August 10, 2020               [Page 13]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
    [RFC8259]  Bray, T., Ed., "The JavaScript Object Notation (JSON) Data
               Interchange Format", STD 90, RFC 8259,
@@ -773,18 +777,20 @@ Appendix A.  Other Streaming Specifications
 
    XMPP Events
 
+
+
+
+
+Backman, et al.         Expires October 29, 2020               [Page 14]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    The WG considered XMPP Events and their ability to provide a single
    messaging solution without the need for both polling and push modes.
    The feeling was the size and methodology of XMPP was too far apart
    from the current capabilities of the SECEVENTs community, which
    focuses in on HTTP based service delivery and authorization.
-
-
-
-Backman, et al.          Expires August 10, 2020               [Page 14]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
    Amazon Simple Notification Service
 
@@ -826,6 +832,16 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
 
    Google Pub/Sub
 
+
+
+
+
+
+Backman, et al.         Expires October 29, 2020               [Page 15]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    The Google Pub Sub system favors a model whereby polling and
    acknowledgement of events is done with separate endpoints and as
    separate functions.
@@ -833,14 +849,6 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
    Information:
 
    o  Cloud Overview - https://cloud.google.com/pubsub/
-
-
-
-
-Backman, et al.          Expires August 10, 2020               [Page 15]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
    o  Subscriber Overview - https://cloud.google.com/pubsub/docs/
       subscriber
@@ -882,21 +890,20 @@ Appendix C.  Change Log
    o  Renamed Event Transmitter and Event Receiver to SET Transmitter
       and SET Receiver, respectively.
 
+
+
+
+Backman, et al.         Expires October 29, 2020               [Page 16]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    o  Added IANA registry for SET Delivery Error Codes.
 
    o  Removed enumeration of HTTP authentication methods.
 
    o  Removed generally applicable guidance for HTTP, authorization
       tokens, and bearer tokens.
-
-
-
-
-
-Backman, et al.          Expires August 10, 2020               [Page 16]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
    o  Moved guidance for using authentication methods as DoS protection
       to Security Considerations.
@@ -940,19 +947,17 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
    o  Consolidated definition of error response under Failure Response
       section.
 
+
+
+Backman, et al.         Expires October 29, 2020               [Page 17]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    o  Removed Event Delivery Process section and moved its content to
       parent section.
 
    o  Readability edits to SET Delivery section and its subsections.
-
-
-
-
-
-Backman, et al.          Expires August 10, 2020               [Page 17]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
    o  Added callout that SET Receiver HTTP endpoint configuration is
       out-of-scope.
@@ -997,18 +1002,18 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
    o  Added error description language preferences and specification via
       "Accept-Language" and "Content-Language" headers.
 
+
+
+
+Backman, et al.         Expires October 29, 2020               [Page 18]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    o  Added "recognized issuer" validation requirement in section 2.
 
    o  Added timeouts as an acceptable reason to resend a SET in section
       2.
-
-
-
-
-Backman, et al.          Expires August 10, 2020               [Page 18]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
    o  Edited text in section 1 to clarify that configuration is out of
       scope.
@@ -1053,18 +1058,19 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
    o  Reworded guidance around signing and/or encrypting SETs for
       integrity protection.
 
+
+
+
+Backman, et al.         Expires October 29, 2020               [Page 19]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
    o  Renamed TLS "Support Considerations" section to "Confidentiality
       of SETs".
 
    o  Reworded guidance around subject identifier selection and privacy
       concerns.
-
-
-
-Backman, et al.          Expires August 10, 2020               [Page 19]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
-
 
    Draft 06 - mbj, MS:
 
@@ -1100,6 +1106,27 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
 
    o  Corrected editorial nits.
 
+   Draft 10 - AB
+
+   o  Addressed area director review comments by Benamin Kaduk:
+
+      *  Added reference to 8417 as definition document for SETs.
+
+      *  Added text clarifying that determining the SET Recipient's
+         service identity is out of scope.
+
+
+
+Backman, et al.         Expires October 29, 2020               [Page 20]
+
+Internet-Draft        draft-ietf-secevent-http-push           April 2020
+
+
+      *  Added normative recommendation for transmitters to target SETs
+         to specific business needs of subscribers.
+
+      *  Minor editorial corrections.
+
 Authors' Addresses
 
    Annabelle Backman (editor)
@@ -1113,13 +1140,6 @@ Authors' Addresses
 
    Email: mbj@microsoft.com
    URI:   http://self-issued.info/
-
-
-
-
-Backman, et al.          Expires August 10, 2020               [Page 20]
-
-Internet-Draft        draft-ietf-secevent-http-push        February 2020
 
 
    Marius Scurtescu
@@ -1153,24 +1173,4 @@ Internet-Draft        draft-ietf-secevent-http-push        February 2020
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Backman, et al.          Expires August 10, 2020               [Page 21]
+Backman, et al.         Expires October 29, 2020               [Page 21]

--- a/draft-ietf-secevent-http-push.xml
+++ b/draft-ietf-secevent-http-push.xml
@@ -11,7 +11,7 @@
 <?rfc inline="yes"?>
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
-<rfc category="std" docName="draft-ietf-secevent-http-push-09" ipr="trust200902">
+<rfc category="std" docName="draft-ietf-secevent-http-push-10" ipr="trust200902">
     <front>
         <title abbrev="draft-ietf-secevent-http-push">Push-Based Security Event Token (SET) Delivery Using HTTP</title>
 
@@ -51,7 +51,7 @@
             </address>
         </author>
 
-	<date year="2020" month="February" day="7" />
+	<date year="2020" month="April" day="27" />
 
         <area>Security</area>
         <workgroup>Security Events Working Group</workgroup>
@@ -91,7 +91,9 @@
             <t>
                 A mechanism for exchanging configuration metadata such as endpoint URLs
                 and cryptographic keys between the transmitter and recipient is
-                out of scope for this specification.
+                out of scope for this specification. How SETs are defined and the process
+                by which security events are identified for SET Recipients are specified
+                in <xref target="RFC8417"/>.
             </t>
             
             <section anchor="notat" title="Notational Conventions" toc="default">
@@ -441,7 +443,7 @@ Content-Type: application/json
 
             <section title="Confidentiality of SETs">
                 <t>SETs may contain sensitive information that is considered Personally Identifiable
-                    Information (e.g., subject claims). In such cases, SET Transmitters and
+                    Information (PII). In such cases, SET Transmitters and
                     SET Recipients MUST protect the confidentiality of the SET contents by
                     encrypting the SET as described in <xref target="RFC7516">JWE</xref>,
                     using a transport-layer security mechanism such as TLS, or both. If
@@ -451,6 +453,8 @@ Content-Type: application/json
 		    which as of the time of this publication is TLS 1.3 <xref target="RFC8446"/>.
 		    When using TLS, the client MUST
                     perform a TLS/SSL server certificate check using DNS-ID <xref target="RFC6125"/>.
+                    How a SET Transmitter determines the expected service identity to match the SET
+                    Recipient's server certificate against is out of scope for this document.
                     Implementation security considerations for TLS can be found in
                     "Recommendations for Secure Use of TLS and DTLS" <xref target="RFC7525"/>.</t>
             </section>
@@ -482,6 +486,10 @@ Content-Type: application/json
         </section>
 
         <section title="Privacy Considerations">
+            <t>
+                SET Transmistters SHOULD attempt to deliver SETs that are targeted to the specific
+                business and protocol needs of subscribers.
+            </t>
 
             <t>When sharing personally identifiable information or information
                 that is otherwise considered confidential to affected users, SET
@@ -849,6 +857,26 @@ need for assurance.</artwork>
 		</t>
 	      </list>
 	    </t>
+            <t>
+                Draft 10 - AB
+                <list style="symbols">
+                    <t>
+                        Addressed area director review comments by Benamin Kaduk:
+                        <list style="symbols">
+                            <t>Added reference to 8417 as definition document for SETs.</t>
+                            <t>
+                                Added text clarifying that determining the SET Recipient's service identity
+                                is out of scope.
+                            </t>
+                            <t>
+                                Added normative recommendation for transmitters to target SETs to specific
+                                business needs of subscribers.
+                            </t>
+                            <t>Minor editorial corrections.</t>
+                        </list>
+                    </t>
+                </list>
+            </t>
         </section>
     </back>
 </rfc>


### PR DESCRIPTION
1. Section 1 of -push should get the sentence "How SETs are defined and the process by which security events are identified for SET Recipients are specified in [RFC8417]."
2. In Section 5.3 of -push, replace "e.g., subject claims" with "PII" as was already done in -poll.
3. In Security Considerations for -push and -poll, add text explaining that determining the expected service identity to match against using DNS-ID is out of scope.
4. In Privacy Considerations for -push, add "SET Transmistters SHOULD attempt to deliver SETs that are targeted to the specific business and protocol needs of subscribers", as already exists within -poll.