### PR TITLE
Clarifying "at least once" delivery expectation

### DIFF
--- a/draft-ietf-secevent-http-push.html
+++ b/draft-ietf-secevent-http-push.html
@@ -405,14 +405,14 @@
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.46.0 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.35.0 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Backman, A., Ed., Jones, M., Ed., Scurtescu, M., Ansari, M., and A. Nadalin" />
-  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-secevent-http-push-13" />
-  <meta name="dct.issued" scheme="ISO8601" content="2020-06-24" />
-  <meta name="dct.abstract" content="This specification defines how a Security Event Token (SET) can be delivered to an intended recipient using HTTP POST over TLS.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.   " />
-  <meta name="description" content="This specification defines how a Security Event Token (SET) can be delivered to an intended recipient using HTTP POST over TLS.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.   " />
+  <meta name="dct.identifier" content="urn:ietf:id:draft-ietf-secevent-http-push-14" />
+  <meta name="dct.issued" scheme="ISO8601" content="2020-06-26" />
+  <meta name="dct.abstract" content="This specification defines how a Security Event Token (SET) can be delivered to an intended recipient using HTTP POST over TLS.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  " />
+  <meta name="description" content="This specification defines how a Security Event Token (SET) can be delivered to an intended recipient using HTTP POST over TLS.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  " />
 
 </head>
 
@@ -434,7 +434,7 @@
 <td class="right">M. Jones, Ed.</td>
 </tr>
 <tr>
-<td class="left">Expires: December 26, 2020</td>
+<td class="left">Expires: December 28, 2020</td>
 <td class="right">Microsoft</td>
 </tr>
 <tr>
@@ -463,7 +463,7 @@
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">June 24, 2020</td>
+<td class="right">June 26, 2020</td>
 </tr>
 
     	
@@ -471,7 +471,7 @@
   </table>
 
   <p class="title">Push-Based Security Event Token (SET) Delivery Using HTTP<br />
-  <span class="filename">draft-ietf-secevent-http-push-13</span></p>
+  <span class="filename">draft-ietf-secevent-http-push-14</span></p>
   
   <h1 id="rfc.abstract"><a href="#rfc.abstract">Abstract</a></h1>
 <p>This specification defines how a Security Event Token (SET) can be delivered to an intended recipient using HTTP POST over TLS.  The SET is transmitted in the body of an HTTP POST request to an endpoint operated by the recipient, and the recipient indicates successful or failed transmission via the HTTP response.  </p>
@@ -479,7 +479,7 @@
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on December 26, 2020.</p>
+<p>This Internet-Draft will expire on December 28, 2020.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2020 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -599,9 +599,9 @@
 <p> </p>
 <p id="rfc.section.2.p.3">The mechanisms by which the SET Recipient performs this validation are out of scope for this document. SET parsing, issuer identification, and audience identification are defined in <a href="#RFC8417" class="xref">[RFC8417]</a>.  The mechanism for validating the authenticity of a SET is deployment specific, and may vary depending on the authentication mechanisms in use, and whether the SET is signed and/or encrypted (See <a href="#aa" class="xref">Section 3</a>).  </p>
 <p id="rfc.section.2.p.4">SET Transmitters MAY transmit SETs issued by another entity. The SET Recipient may accept or reject (i.e., return an error response such as <samp>access_denied</samp>) a SET at its own discretion.  </p>
-<p id="rfc.section.2.p.5">The SET Recipient persists the SET in a way that is sufficient to meet the SET Recipient's own reliability requirements, and MUST NOT expect or depend on a SET Transmitter to re-transmit or otherwise make available to the SET Recipient a SET once the SET Recipient acknowledges that it was received successfully.  The level and method of retention of SETs by SET Recipients is out of scope of this specification.  </p>
-<p id="rfc.section.2.p.6">Once the SET has been validated and persisted, the SET Recipient SHOULD immediately return a response indicating that the SET was successfully delivered. The SET Recipient SHOULD NOT perform further processing of the SET beyond the required validation steps prior to sending this response.  Any additional steps SHOULD be executed asynchronously from delivery to minimize the time the SET Transmitter is waiting for a response.  </p>
-<p id="rfc.section.2.p.7">The SET Transmitter MAY re-transmit a SET if the responses from previous transmissions timed out or indicated potentially recoverable errors (such as server unavailability that may be transient). In all other cases, the SET Transmitter SHOULD NOT re-transmit a SET. The SET Transmitter SHOULD delay retransmission for an appropriate amount of time to avoid overwhelming the SET Recipient (see <a href="#reliability" class="xref">Section 4</a>).  </p>
+<p id="rfc.section.2.p.5">The SET Recipient persists the SET in a way that is sufficient to meet the SET Recipient's own reliability requirements.  The level and method of retention of SETs by SET Recipients is out of scope of this specification.  Once the SET has been validated and persisted, the SET Recipient SHOULD immediately return a response indicating that the SET was successfully delivered. The SET Recipient SHOULD NOT perform further processing of the SET beyond the required validation steps prior to sending this response.  Any additional steps SHOULD be executed asynchronously from delivery to minimize the time the SET Transmitter is waiting for a response.  </p>
+<p id="rfc.section.2.p.6">The SET Transmitter MAY transmit the same SET to the SET Recipient multiple times, regardless of the response from the SET Recipient. The SET Recipient MUST respond as it would if the SET had not been previously received by the SET Recipient. The SET Recipient MUST NOT expect or depend on a SET Transmitter to re-transmit a SET or otherwise make a SET available to the SET Recipient once the SET Recipient acknowledges that it was received successfully.  </p>
+<p id="rfc.section.2.p.7">The SET Transmitter should not re-transmit a SET unless the SET Transmitter suspects that previous transmissions may have failed due to potentially recoverable errors (such as network outage or temporary service interruption at either the SET Transmitter or SET Recipient). In all other cases, the SET Transmitter SHOULD NOT re-transmit a SET. The SET Transmitter SHOULD delay retransmission for an appropriate amount of time to avoid overwhelming the SET Recipient (see <a href="#reliability" class="xref">Section 4</a>).  </p>
 <h1 id="rfc.section.2.1">
 <a href="#rfc.section.2.1">2.1.</a> <a href="#httpPost" id="httpPost">Transmitting a SET</a>
 </h1>
@@ -749,7 +749,8 @@
 <a href="#rfc.section.4">4.</a> <a href="#reliability" id="reliability">Delivery Reliability</a>
 </h1>
 <p id="rfc.section.4.p.1">Delivery reliability requirements may vary depending upon the use cases.  This specification defines the response from the SET Recipient in such a way as to provide the SET Transmitter with the information necessary to determine what further action is required, if any, in order to meet their requirements.  SET Transmitters with high reliability requirements may be tempted to always retry failed transmissions. However, it should be noted that for many types of SET delivery errors, a retry is extremely unlikely to be successful.  For example, <samp>invalid_request</samp> indicates a structural error in the content of the request body that is likely to remain when re-transmitting the same SET.  Others such as <samp>access_denied</samp> may be transient, for example if the SET Transmitter refreshes expired credentials prior to re-transmission.  </p>
-<p id="rfc.section.4.p.2">Implementers SHOULD evaluate the reliability requirements of their use cases and the impact of various retry mechanisms on the performance of their systems to determine an appropriate strategy for handling various error conditions.  </p>
+<p id="rfc.section.4.p.2">The SET Transmitter may be unaware of whether or not a SET has been delivered to a SET Recipient. For example, a network interruption could prevent the SET Transmitter from receiving the success response, or a service outage could prevent the SET Transmitter from recording the fact that the SET was delivered.  It is left to the implementer to decide how to handle such cases, based on their requirements. For example, it may be appropriate for the SET Transmitter to transmit the SET to the SET Recipient, erring on the side of guaranteeing delivery, or it may be appropriate to assume delivery was successful, erring on the side of not spending resources re-transmitting previously delivered SETs. Other options, such as sending the SET to a "dead letter queue" for manual examination may also be appropriate.  </p>
+<p id="rfc.section.4.p.3">Implementers SHOULD evaluate the reliability requirements of their use cases and the impact of various retry mechanisms and re-transmission policies on the performance of their systems to determine an appropriate strategy for handling various error conditions.  </p>
 <h1 id="rfc.section.5">
 <a href="#rfc.section.5">5.</a> <a href="#Security" id="Security">Security Considerations</a>
 </h1>
@@ -1204,6 +1205,14 @@ need for assurance.</pre>
 <p id="rfc.section.D.p.15">Draft 13 - mbj </p>
 
 <ul><li>Addressed IESG comments.  </li></ul>
+
+<p> </p>
+<p id="rfc.section.D.p.16">Draft 14 - AB </p>
+
+<ul>
+<li>Revised normative requirements for SET re-transmission to clarify "at least once" delivery expectiations.  </li>
+<li>Added non-normative text to Section 4 - Delivery Reliability describing conditions where re-transmission of successfully delivered SETs may occur.  </li>
+</ul>
 
 <p> </p>
 <h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>

--- a/draft-ietf-secevent-http-push.txt
+++ b/draft-ietf-secevent-http-push.txt
@@ -5,18 +5,18 @@
 Security Events Working Group                            A. Backman, Ed.
 Internet-Draft                                                    Amazon
 Intended status: Standards Track                           M. Jones, Ed.
-Expires: December 26, 2020                                     Microsoft
+Expires: December 28, 2020                                     Microsoft
                                                             M. Scurtescu
                                                                 Coinbase
                                                                M. Ansari
                                                                    Cisco
                                                               A. Nadalin
                                                                Microsoft
-                                                           June 24, 2020
+                                                           June 26, 2020
 
 
        Push-Based Security Event Token (SET) Delivery Using HTTP
-                    draft-ietf-secevent-http-push-13
+                    draft-ietf-secevent-http-push-14
 
 Abstract
 
@@ -41,7 +41,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on December 26, 2020.
+   This Internet-Draft will expire on December 28, 2020.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Backman, et al.         Expires December 26, 2020               [Page 1]
+Backman, et al.         Expires December 28, 2020               [Page 1]
 
 Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
@@ -87,16 +87,16 @@ Table of Contents
    6.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .  11
    7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
      7.1.  Security Event Token Delivery Error Codes . . . . . . . .  12
-       7.1.1.  Registration Template . . . . . . . . . . . . . . . .  12
+       7.1.1.  Registration Template . . . . . . . . . . . . . . . .  13
        7.1.2.  Initial Registry Contents . . . . . . . . . . . . . .  13
    8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  14
      8.1.  Normative References  . . . . . . . . . . . . . . . . . .  14
-     8.2.  Informative References  . . . . . . . . . . . . . . . . .  15
+     8.2.  Informative References  . . . . . . . . . . . . . . . . .  16
    Appendix A.  Unencrypted Transport Considerations . . . . . . . .  16
-   Appendix B.  Other Streaming Specifications . . . . . . . . . . .  16
+   Appendix B.  Other Streaming Specifications . . . . . . . . . . .  17
    Appendix C.  Acknowledgments  . . . . . . . . . . . . . . . . . .  18
-   Appendix D.  Change Log . . . . . . . . . . . . . . . . . . . . .  18
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  23
+   Appendix D.  Change Log . . . . . . . . . . . . . . . . . . . . .  19
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  24
 
 1.  Introduction and Overview
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Backman, et al.         Expires December 26, 2020               [Page 2]
+Backman, et al.         Expires December 28, 2020               [Page 2]
 
 Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
@@ -165,7 +165,7 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
 
 
-Backman, et al.         Expires December 26, 2020               [Page 3]
+Backman, et al.         Expires December 28, 2020               [Page 3]
 
 Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
@@ -205,36 +205,40 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
    as "access_denied") a SET at its own discretion.
 
    The SET Recipient persists the SET in a way that is sufficient to
-   meet the SET Recipient's own reliability requirements, and MUST NOT
-   expect or depend on a SET Transmitter to re-transmit or otherwise
-   make available to the SET Recipient a SET once the SET Recipient
-   acknowledges that it was received successfully.  The level and method
-   of retention of SETs by SET Recipients is out of scope of this
-   specification.
+   meet the SET Recipient's own reliability requirements.  The level and
+   method of retention of SETs by SET Recipients is out of scope of this
+   specification.  Once the SET has been validated and persisted, the
+   SET Recipient SHOULD immediately return a response indicating that
+   the SET was successfully delivered.  The SET Recipient SHOULD NOT
+   perform further processing of the SET beyond the required validation
+   steps prior to sending this response.  Any additional steps SHOULD be
+   executed asynchronously from delivery to minimize the time the SET
+   Transmitter is waiting for a response.
 
-   Once the SET has been validated and persisted, the SET Recipient
-   SHOULD immediately return a response indicating that the SET was
-   successfully delivered.  The SET Recipient SHOULD NOT perform further
-   processing of the SET beyond the required validation steps prior to
-   sending this response.  Any additional steps SHOULD be executed
+   The SET Transmitter MAY transmit the same SET to the SET Recipient
+   multiple times, regardless of the response from the SET Recipient.
+   The SET Recipient MUST respond as it would if the SET had not been
 
 
 
-
-Backman, et al.         Expires December 26, 2020               [Page 4]
+Backman, et al.         Expires December 28, 2020               [Page 4]
 
 Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
 
-   asynchronously from delivery to minimize the time the SET Transmitter
-   is waiting for a response.
+   previously received by the SET Recipient.  The SET Recipient MUST NOT
+   expect or depend on a SET Transmitter to re-transmit a SET or
+   otherwise make a SET available to the SET Recipient once the SET
+   Recipient acknowledges that it was received successfully.
 
-   The SET Transmitter MAY re-transmit a SET if the responses from
-   previous transmissions timed out or indicated potentially recoverable
-   errors (such as server unavailability that may be transient).  In all
-   other cases, the SET Transmitter SHOULD NOT re-transmit a SET.  The
-   SET Transmitter SHOULD delay retransmission for an appropriate amount
-   of time to avoid overwhelming the SET Recipient (see Section 4).
+   The SET Transmitter should not re-transmit a SET unless the SET
+   Transmitter suspects that previous transmissions may have failed due
+   to potentially recoverable errors (such as network outage or
+   temporary service interruption at either the SET Transmitter or SET
+   Recipient).  In all other cases, the SET Transmitter SHOULD NOT re-
+   transmit a SET.  The SET Transmitter SHOULD delay retransmission for
+   an appropriate amount of time to avoid overwhelming the SET Recipient
+   (see Section 4).
 
 2.1.  Transmitting a SET
 
@@ -273,11 +277,7 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
 
 
-
-
-
-
-Backman, et al.         Expires December 26, 2020               [Page 5]
+Backman, et al.         Expires December 28, 2020               [Page 5]
 
 Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
@@ -333,7 +333,7 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
 
 
-Backman, et al.         Expires December 26, 2020               [Page 6]
+Backman, et al.         Expires December 28, 2020               [Page 6]
 
 Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
@@ -389,7 +389,7 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
 
 
-Backman, et al.         Expires December 26, 2020               [Page 7]
+Backman, et al.         Expires December 28, 2020               [Page 7]
 
 Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
@@ -445,7 +445,7 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
 
 
-Backman, et al.         Expires December 26, 2020               [Page 8]
+Backman, et al.         Expires December 28, 2020               [Page 8]
 
 Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
@@ -501,7 +501,7 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
 
 
-Backman, et al.         Expires December 26, 2020               [Page 9]
+Backman, et al.         Expires December 28, 2020               [Page 9]
 
 Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
@@ -515,10 +515,25 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
    transient, for example if the SET Transmitter refreshes expired
    credentials prior to re-transmission.
 
+   The SET Transmitter may be unaware of whether or not a SET has been
+   delivered to a SET Recipient.  For example, a network interruption
+   could prevent the SET Transmitter from receiving the success
+   response, or a service outage could prevent the SET Transmitter from
+   recording the fact that the SET was delivered.  It is left to the
+   implementer to decide how to handle such cases, based on their
+   requirements.  For example, it may be appropriate for the SET
+   Transmitter to transmit the SET to the SET Recipient, erring on the
+   side of guaranteeing delivery, or it may be appropriate to assume
+   delivery was successful, erring on the side of not spending resources
+   re-transmitting previously delivered SETs.  Other options, such as
+   sending the SET to a "dead letter queue" for manual examination may
+   also be appropriate.
+
    Implementers SHOULD evaluate the reliability requirements of their
-   use cases and the impact of various retry mechanisms on the
-   performance of their systems to determine an appropriate strategy for
-   handling various error conditions.
+   use cases and the impact of various retry mechanisms and re-
+   transmission policies on the performance of their systems to
+   determine an appropriate strategy for handling various error
+   conditions.
 
 5.  Security Considerations
 
@@ -539,6 +554,14 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
    SETs may contain sensitive information, including Personally
    Identifiable Information (PII), or be distributed through third
    parties.  In such cases, SET Transmitters and SET Recipients MUST
+
+
+
+Backman, et al.         Expires December 28, 2020              [Page 10]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
    protect the confidentiality of the SET contents.  TLS MUST be used to
    secure the transmitted SETs.  In some use cases, encrypting the SET
    as described in JWE [RFC7516] will also be required.  The Event
@@ -552,15 +575,6 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
    document.  The implementation security considerations for TLS in
    "Recommendations for Secure Use of TLS and DTLS" [RFC7525] MUST be
    followed.
-
-
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 10]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
-
 
 5.4.  Denial of Service
 
@@ -596,6 +610,14 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
    Transmitters and Recipients MUST have the appropriate legal
    agreements and user consent or terms of service in place.
    Furthermore, data that needs confidentiality protection MUST be
+
+
+
+Backman, et al.         Expires December 28, 2020              [Page 11]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
    encrypted, at least with TLS and sometimes also using JSON Web
    Encryption (JWE) [RFC7516].
 
@@ -606,17 +628,6 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
    identifier with a SET Recipient (e.g., whether doing so could enable
    correlation and/or de-anonymization of data) and choose appropriate
    subject identifiers for their use cases.
-
-
-
-
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 11]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
-
 
 7.  IANA Considerations
 
@@ -654,6 +665,15 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
    Expert, that Expert should defer to the judgment of the other
    Experts.
 
+
+
+
+
+Backman, et al.         Expires December 28, 2020              [Page 12]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
 7.1.1.  Registration Template
 
    Error Code
@@ -666,13 +686,6 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
    Description
       A brief human-readable description of the Security Event Token
       Delivery Error Code.
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 12]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
-
 
    Change Controller
       For error codes registered by the IETF or its working groups, list
@@ -709,6 +722,14 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
       Change Controller: IETF
       Defining Document(s): Section 2.4 of [[ this specification ]]
 
+
+
+
+Backman, et al.         Expires December 28, 2020              [Page 13]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
       Error Code: invalid_audience
       Description: The SET audience does not correspond to the SET
       Recipient.
@@ -722,14 +743,6 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
       Defining Document(s): Section 2.4 of [[ this specification ]]
 
       Error Code: access_denied
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 13]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
-
-
       Description: The SET Transmitter is not authorized to transmit the
       SET to the SET Recipient.
       Change Controller: IETF
@@ -764,6 +777,15 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
               Security (TLS)", RFC 6125, DOI 10.17487/RFC6125, March
               2011, <https://www.rfc-editor.org/info/rfc6125>.
 
+
+
+
+
+Backman, et al.         Expires December 28, 2020              [Page 14]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
    [RFC6698]  Hoffman, P. and J. Schlyter, "The DNS-Based Authentication
               of Named Entities (DANE) Transport Layer Security (TLS)
               Protocol: TLSA", RFC 6698, DOI 10.17487/RFC6698, August
@@ -778,13 +800,6 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
               Protocol (HTTP/1.1): Semantics and Content", RFC 7231,
               DOI 10.17487/RFC7231, June 2014,
               <https://www.rfc-editor.org/info/rfc7231>.
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 14]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
-
 
    [RFC7515]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web
               Signature (JWS)", RFC 7515, DOI 10.17487/RFC7515, May
@@ -818,6 +833,15 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
               DOI 10.17487/RFC8259, December 2017,
               <https://www.rfc-editor.org/info/rfc8259>.
 
+
+
+
+
+Backman, et al.         Expires December 28, 2020              [Page 15]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
    [RFC8417]  Hunt, P., Ed., Jones, M., Denniss, W., and M. Ansari,
               "Security Event Token (SET)", RFC 8417,
               DOI 10.17487/RFC8417, July 2018,
@@ -834,13 +858,6 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
               Nadalin, "Poll-Based Security Event Token (SET) Delivery
               Using HTTP", draft-ietf-secevent-http-poll-11 (work in
               progress), June 2020.
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 15]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
-
 
    [RFC7235]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
               Protocol (HTTP/1.1): Authentication", RFC 7235,
@@ -872,6 +889,15 @@ Appendix A.  Unencrypted Transport Considerations
    padding algorithms to prevent side channels remain an open research
    topic.)
 
+
+
+
+
+Backman, et al.         Expires December 28, 2020              [Page 16]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
 Appendix B.  Other Streaming Specifications
 
    [[ NOTE TO THE RFC EDITOR: This section to be removed prior to
@@ -885,18 +911,6 @@ Appendix B.  Other Streaming Specifications
    In addition to this specification, the WG is defining a polling-based
    SET delivery protocol.  That protocol [I-D.ietf-secevent-http-poll]
    describes it as:
-
-
-
-
-
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 16]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
-
 
    This specification defines how a series of Security Event Tokens
    (SETs) can be delivered to an intended recipient using HTTP POST over
@@ -933,6 +947,13 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
    Other information:
 
+
+
+Backman, et al.         Expires December 28, 2020              [Page 17]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
    o  API Reference:
       http://docs.aws.amazon.com/AWSSimpleQueueService/latest/
       APIReference/Welcome.html
@@ -946,14 +967,6 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
    Apache Kafka is an Apache open source project based upon TCP for
    distributed streaming.  It prescribes some interesting general-
    purpose features that seem to extend far beyond the simpler streaming
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 17]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
-
-
    model that SECEVENTs is after.  A comment from MS has been that Kafka
    does an acknowledge with poll combination event which seems to be a
    performance advantage.  See: https://kafka.apache.org/intro
@@ -989,6 +1002,14 @@ Appendix C.  Acknowledgments
    Yaron Sheffer, Robert Sparks, Valery Smyslov, Eric Vyncke, and Robert
    Wilton.
 
+
+
+
+Backman, et al.         Expires December 28, 2020              [Page 18]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
 Appendix D.  Change Log
 
    [[ NOTE TO THE RFC EDITOR: This section to be removed prior to
@@ -1002,13 +1023,6 @@ Appendix D.  Change Log
    o  Removed references to the HTTP Polling delivery method.
 
    o  Removed informative reference to RFC6202.
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 18]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
-
 
    Draft 01 - AB:
 
@@ -1045,6 +1059,13 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
    o  Removed inapplicable notes about example formatting.
 
+
+
+Backman, et al.         Expires December 28, 2020              [Page 19]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
    o  Removed text about SET creation and handling.
 
    o  Removed duplication in protocol description.
@@ -1057,14 +1078,6 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
    Draft 02 - AB:
 
    o  Rewrote abstract and introduction.
-
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 19]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
-
 
    o  Rewrote definitions for SET Transmitter, SET Receiver.
 
@@ -1102,6 +1115,13 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
    o  Applied editorial and minor normative corrections.
 
+
+
+Backman, et al.         Expires December 28, 2020              [Page 20]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
    o  Updated Marius' contact information.
 
    Draft 04 - AB:
@@ -1114,13 +1134,6 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
    o  Removed un-referenced normative references.
 
    o  Added normative reference to JSON in error response definition.
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 20]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
-
 
    o  Added text clarifying that the value of the "description"
       attribute in error responses is implementation specific.
@@ -1158,6 +1171,13 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
    o  Revised SET Delivery Error Code format to allow the same set of
       characters as is allowed in error codes in RFC6749.
 
+
+
+Backman, et al.         Expires December 28, 2020              [Page 21]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
    o  Added mention of HTTP Poll spec to list of other streaming specs
       in appendix.
 
@@ -1167,16 +1187,6 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
    o  Changed responding to errors with an appropriate HTTP status code
       from optional to recommended.
-
-
-
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 21]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
-
 
    o  Changed Error Codes registry change policy from Expert Review to
       First Come First Served; added guidance that error codes are meant
@@ -1216,6 +1226,14 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
    Draft 07 - AB:
 
+
+
+
+Backman, et al.         Expires December 28, 2020              [Page 22]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
    o  Made minor editorial corrections.
 
    o  Removed "SET Recipient" definition and added explicit list of
@@ -1226,13 +1244,6 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
    o  Addressed area director review comments by Benjamin Kaduk.
 
    Draft 09 - mbj + AB
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 22]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
-
 
    o  Corrected editorial nits.
 
@@ -1267,6 +1278,22 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
    o  Addressed IESG comments.
 
+   Draft 14 - AB
+
+   o  Revised normative requirements for SET re-transmission to clarify
+      "at least once" delivery expectiations.
+
+
+
+Backman, et al.         Expires December 28, 2020              [Page 23]
+
+Internet-Draft        draft-ietf-secevent-http-push            June 2020
+
+
+   o  Added non-normative text to Section 4 - Delivery Reliability
+      describing conditions where re-transmission of successfully
+      delivered SETs may occur.
+
 Authors' Addresses
 
    Annabelle Backman (editor)
@@ -1280,14 +1307,6 @@ Authors' Addresses
 
    Email: mbj@microsoft.com
    URI:   https://self-issued.info/
-
-
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 23]
-
-Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
 
    Marius Scurtescu
@@ -1322,23 +1341,4 @@ Internet-Draft        draft-ietf-secevent-http-push            June 2020
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Backman, et al.         Expires December 26, 2020              [Page 24]
+Backman, et al.         Expires December 28, 2020              [Page 24]

--- a/draft-ietf-secevent-http-push.xml
+++ b/draft-ietf-secevent-http-push.xml
@@ -11,7 +11,7 @@
 <?rfc inline="yes"?>
 <?rfc compact="yes"?>
 <?rfc subcompact="no"?>
-<rfc category="std" docName="draft-ietf-secevent-http-push-13" ipr="trust200902">
+<rfc category="std" docName="draft-ietf-secevent-http-push-14" ipr="trust200902">
     <front>
         <title abbrev="draft-ietf-secevent-http-push">Push-Based Security Event Token (SET) Delivery Using HTTP</title>
 
@@ -51,7 +51,7 @@
             </address>
         </author>
 
-	<date year="2020" month="June" day="24" />
+	<date year="2020" month="June" day="26" />
 
         <area>Security</area>
         <workgroup>Security Events Working Group</workgroup>
@@ -187,14 +187,9 @@
             </t>
             <t>
                 The SET Recipient persists the SET in a way that
-                is sufficient to meet the SET Recipient's own reliability requirements,
-                and MUST NOT expect or depend on a SET Transmitter to re-transmit or
-                otherwise make available to the SET Recipient a SET once the SET Recipient
-                acknowledges that it was received successfully.
+                is sufficient to meet the SET Recipient's own reliability requirements.
 		The level and method of retention of SETs
 		by SET Recipients is out of scope of this specification.
-            </t>
-            <t>
                 Once the SET has been validated and persisted, the SET Recipient SHOULD
                 immediately return a response indicating that the SET was successfully
                 delivered. The SET Recipient SHOULD NOT perform further processing of the SET
@@ -203,10 +198,19 @@
 		to minimize the time the SET Transmitter is waiting for a response.
             </t>
             <t>
-                The SET Transmitter MAY re-transmit a SET if the responses from previous
-                transmissions timed out or indicated potentially recoverable errors (such
-                as server unavailability that may be transient). In all
-                other cases, the SET Transmitter SHOULD NOT re-transmit a SET. The SET
+                The SET Transmitter MAY transmit the same SET to the SET Recipient multiple
+                times, regardless of the response from the SET Recipient. The SET Recipient
+                MUST respond as it would if the SET had not been previously received by the 
+                SET Recipient. The SET Recipient MUST NOT expect or depend on a SET Transmitter
+                to re-transmit a SET or otherwise make a SET available to the SET Recipient
+                once the SET Recipient acknowledges that it was received successfully.
+            </t>
+            <t>
+                The SET Transmitter should not re-transmit a SET unless the SET Transmitter
+                suspects that previous transmissions may have failed due to potentially
+                recoverable errors (such as network outage or temporary service interruption at
+                either the SET Transmitter or SET Recipient). In all other cases, the SET
+                Transmitter SHOULD NOT re-transmit a SET. The SET
                 Transmitter SHOULD delay retransmission for an appropriate amount of time
                 to avoid overwhelming the SET Recipient (see <xref target="reliability"/>).
             </t>
@@ -425,9 +429,23 @@
                 credentials prior to re-transmission.
             </t>
             <t>
+                The SET Transmitter may be unaware of whether or not a SET has been delivered
+                to a SET Recipient. For example, a network interruption could prevent the
+                SET Transmitter from receiving the success response, or a service outage could
+                prevent the SET Transmitter from recording the fact that the SET was delivered. 
+                It is left to the implementer to decide how to handle such cases, based on
+                their requirements. For example, it may be appropriate for the SET Transmitter to
+                transmit the SET to the SET Recipient, erring on the side of guaranteeing delivery,
+                or it may be appropriate to assume delivery was successful, erring on the side of
+                not spending resources re-transmitting previously delivered SETs. Other options,
+                such as sending the SET to a "dead letter queue" for manual examination may also
+                be appropriate.
+            </t>
+            <t>
                 Implementers SHOULD evaluate the reliability requirements of their use cases and the
-                impact of various retry mechanisms on the performance of their systems
-                to determine an appropriate strategy for handling various error conditions.
+                impact of various retry mechanisms and re-transmission policies on the performance
+                of their systems to determine an appropriate strategy for handling various error
+                conditions.
             </t>
         </section>
         <section anchor="Security" title="Security Considerations" toc="default">
@@ -1008,6 +1026,19 @@ need for assurance.</artwork>
 		</t>
 	      </list>
 	    </t>
+            <t>
+                Draft 14 - AB
+                <list style="symbols">
+                    <t>
+                        Revised normative requirements for SET re-transmission to clarify "at least once"
+                        delivery expectiations.
+                    </t>
+                    <t>
+                        Added non-normative text to Section 4 - Delivery Reliability describing conditions
+                        where re-transmission of successfully delivered SETs may occur.
+                    </t>
+                </list>
+            </t>
         </section>
     </back>
 </rfc>


### PR DESCRIPTION
This change explicitly allows the SET Transmitter to re-transmit SETs that were successfully delivered if it doesn't know they were successfully delivered, and requires the SET Recipient to respond as if they were not re-transmissions.

I also added a non-normative paragraph under Delivery Reliability to give context for when and why this might occur.